### PR TITLE
feat(autoinstall): add user-data renderer (pivot slice one)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,104 @@
+# Pivot: from imperative ZFS installer → autoinstall user-data renderer
+
+## Goal
+Pivot the tool away from reimplementing an installer (debootstrap + ZFS + chroot over
+SSH) toward **generating the proven, known-good subiquity autoinstall `user-data`** (the
+hand-tuned len-serv-003 config) parameterized per host, then driving the native Ubuntu
+installer and validating the result. This first PR delivers only **slice one**: a pure,
+unit-tested renderer that reproduces the known-good artifacts byte-for-byte. No server
+placement, no flip, no reboot yet.
+
+## Why this shape (decisions already made, not open questions)
+- **Template as text, not structure.** The payload is a large inline bash heredoc; modeling
+  it structurally would be self-harm. We template the committed 003 `user-data` as text.
+- **Emit directly; REPLACE `register-gen.py`.** Confirmed by reading it on the server:
+  it is *stale* — it still emits the old broken late-commands (external chroot script +
+  manual `mount --bind`/`chroot`) and its chroot script has no clevis bind, no dracut
+  network-unlock config, no `curtin in-target`. The known-good 003 user-data is ahead of
+  it. This tool becomes the source of truth for the template; **once the generator works
+  we retire register-gen.py entirely** (it is not a backport target).
+- **Template is overridable, not hard-coded.** The known-good 003 template ships embedded
+  as the default (`include_str!`), but a `--template <file>` flag lets anyone supply their
+  own template file. Placeholders are documented so future changes are a template edit, not
+  a Rust change. This keeps the tool a thin, data-driven renderer.
+- **The substitution set is already proven.** This session's verified 001/002-vs-003 diff
+  *is* the template spec: `hostname` (identity + messages + flip path + variables HOSTNAME),
+  `network_address` (NET_ET_ADDRESS + COCKROACH_ADVERTISE), `cockroach_join`. Nothing else.
+- **Leave the ZFS installer code untouched.** Manual install is on hold per user. The new
+  renderer is additive; rip out nothing.
+
+## Affected files (slice one)
+- `tests/fixtures/golden/len-serv-001.user-data` — NEW. Exact copy pulled from the server.
+- `tests/fixtures/golden/len-serv-002.user-data` — NEW. Exact copy pulled from the server.
+- `tests/fixtures/golden/len-serv-003.user-data` — NEW. Exact copy (the template source).
+- `src/autoinstall/mod.rs` — NEW. Module export.
+- `src/autoinstall/host_spec.rs` — NEW. `HostSpec` struct (the per-host inputs) + a
+  `cockroach_join` helper (server + the two other lenservs, excluding self) and
+  `from_installation_config` adapter so existing config/YAML can feed it.
+- `src/autoinstall/render.rs` — NEW. The renderer: `render_user_data(template: &str,
+  spec: &HostSpec) -> Result<String>`, plus `default_template() -> &'static str`
+  (`include_str!` the embedded 003 template) and a loader that uses `--template <file>`
+  when provided, else the default. Substitution is an explicit map of documented
+  placeholders; an unknown/leftover `{{...}}` placeholder is a hard error (so a bad
+  custom template fails loudly rather than shipping a literal `{{FOO}}`).
+- `src/autoinstall/templates/len-serv.user-data.tmpl` — NEW (embedded default). The 003
+  user-data with the proven substitution points turned into placeholders (e.g.
+  `{{HOSTNAME}}`, `{{NET_ADDRESS}}`, `{{COCKROACH_ADVERTISE}}`, `{{COCKROACH_JOIN}}`).
+  Everything else byte-identical to 003. Header comment documents every placeholder so
+  others can fork it.
+- `src/lib.rs` — add `pub mod autoinstall;`.
+- `src/cli/args.rs` — add a `RenderUserData` subcommand (`--config <yaml>` or explicit
+  flags; `--template <file>` optional override; `--output <file>` default stdout). Parsing
+  test alongside existing ones.
+- `src/cli/commands.rs` — `render_user_data_command()` handler.
+- `src/main.rs` — dispatch arm.
+
+## Steps (each independently reviewable / committable)
+1. **Fixtures.** Pull the three known-good `user-data` files verbatim from the server into
+   `tests/fixtures/golden/`. Commit as-is (these are the ground truth the test asserts on).
+2. **Template.** Create the embedded default `len-serv.user-data.tmpl` by copying the 003
+   fixture and replacing ONLY the proven substitution points with placeholders. Diff
+   template-with-003-values against the 003 fixture to prove zero incidental changes.
+   Document every placeholder in a header comment.
+3. **Renderer + HostSpec.** Implement `HostSpec`, `cockroach_join`, `render_user_data`
+   (takes a template string), `default_template()`, and the `--template` loader. Pure
+   functions, no I/O except the optional template-file read. Leftover `{{...}}` = error.
+4. **Golden tests.** Unit tests that render the **default template** with 001/002/003 params
+   and assert **byte-equality** against each fixture. Plus a test that a custom template
+   with an unfilled placeholder errors. This is the whole point — impossible to regress
+   silently against the known-good.
+5. **CLI wiring.** `render-user-data` subcommand (incl. `--template`) → renderer →
+   stdout/file. Add a parse test.
+6. **Docs.** Short section in `docs/netboot-autodeploy.md`: the renderer is the template
+   source of truth, how to supply a custom `--template`, the placeholder list, and that
+   register-gen.py is slated for retirement once placement/drive lands.
+
+## Test strategy
+- Commands: `cargo test` (must stay green; currently 156 pass) and specifically
+  `cargo test --lib autoinstall`.
+- Success criteria:
+  - `render_user_data` with 003's params == `tests/fixtures/golden/len-serv-003.user-data`
+    byte-for-byte.
+  - Same for 001 and 002 params against their fixtures.
+  - `cargo build` clean; clippy no new warnings.
+  - `cargo run -- render-user-data --config examples/configs/...yaml` prints a valid
+    user-data (spot-check it `#cloud-config`-parses).
+
+## Explicitly OUT of scope (later slices, noted so they're not forgotten)
+- **Slice two — `verify <host>`:** SSH into an installed host and validate it matches intent
+  (crypto_LUKS present, `clevis luks list` shows SSS/tang, dracut cmdline has
+  `rd.neednet=1 ip=dhcp`, crypttab, services up). This is where the tool clearly beats
+  register-gen.py.
+- **Slice three — placement & drive:** write the seed into the server netboot tree
+  (`/var/www/html/cloud-init/<hexmac>/` + meta-data + `ipxe/boot/mac-*.ipxe`), then
+  `flip` + reboot (local / remote / "last steps" modes).
+- **arm64 / RPi template variant** (likely just another `--template` file + a tang-server
+  HostSpec variant).
+- **Retiring `register-gen.py`** on the server (happens once slice three — placement &
+  drive — replaces what the script does).
+- **Retiring / gating the ZFS installer path.**
+
+## Rollback
+- All work is on `feat/autoinstall-renderer` in a worktree; new modules are additive and
+  not wired into any existing flow except a new subcommand. Revert = drop the branch /
+  `git worktree remove`. No existing behavior changes, so nothing to undo on `main`.

--- a/docs/netboot-autodeploy.md
+++ b/docs/netboot-autodeploy.md
@@ -1,7 +1,7 @@
 <!-- file: docs/netboot-autodeploy.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 9a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9 -->
-<!-- last-edited: 2026-06-20 -->
+<!-- last-edited: 2026-06-21 -->
 
 # Netboot Autodeploy — Source of Truth & Findings
 
@@ -220,6 +220,58 @@ Concrete starting points when picking this up:
 
 ---
 
+## Renderer (slice one — IMPLEMENTED)
+
+The first slice of the pivot is the **`render-user-data` subcommand**: a pure, data-driven
+renderer that reproduces the proven autoinstall `user-data` per host.
+
+```bash
+# Render to stdout using the embedded (len-serv-003) template:
+ubuntu-autoinstall-agent render-user-data --hostname len-serv-001 --address 172.16.3.92/23
+
+# Use a custom template, write to a file:
+ubuntu-autoinstall-agent render-user-data \
+  --hostname len-serv-002 --address 172.16.3.94/23 \
+  --template ./my-template.user-data.tmpl --output ./out.user-data
+```
+
+How it works:
+- **Template** = the hand-verified len-serv-003 `user-data`, with the per-host bits turned
+  into placeholders. Shipped embedded as the default (`src/autoinstall/templates/
+  len-serv.user-data.tmpl`, `include_str!`); override with `--template <file>`.
+- **Placeholders** (the only things that vary per host — proven by the 001/002/003 diff):
+
+  | Placeholder               | Meaning                          | Example                                   |
+  |---------------------------|----------------------------------|-------------------------------------------|
+  | `{{HOSTNAME}}`            | hostname (×5: identity, msgs, flip, variables) | `len-serv-003`              |
+  | `{{NET_ADDRESS}}`         | IP with CIDR                      | `172.16.3.96/23`                          |
+  | `{{COCKROACH_ADVERTISE}}` | `ip:36357` (derived from address) | `172.16.3.96:36357`                      |
+  | `{{COCKROACH_JOIN}}`      | server first, then other members | `172.16.2.30:36357,172.16.3.92:36357,...` |
+
+- **Cockroach join** is computed by `HostSpec::for_lenserv` (server `172.16.2.30` first,
+  then the other lenserv members excluding self, port `36357`). Members/server/port are
+  constants in `src/autoinstall/host_spec.rs` — edit there to change the fleet.
+- **Safety:** any unfilled `{{...}}` left after substitution is a hard error, so a broken
+  custom template fails loudly instead of shipping a literal placeholder to a machine.
+- **Golden tests** (`src/autoinstall/render.rs`) assert the rendered output is
+  **byte-identical** to `tests/fixtures/golden/len-serv-00{1,2,3}.user-data` (pulled
+  verbatim from the server). This makes silent drift from the known-good impossible.
+
+To change what gets deployed, **edit the template** (or supply your own with `--template`),
+not the Rust. The template is the source of truth.
+
+### Still TODO (later slices)
+- **`verify <host>`** — SSH in and validate a deployed host matches intent (crypto_LUKS,
+  `clevis luks list`, dracut `rd.neednet`, crypttab, services).
+- **Placement & drive** — write the seed into the netboot tree
+  (`/var/www/html/cloud-init/<hexmac>/` + meta-data + `ipxe/boot/mac-*.ipxe`) and flip +
+  reboot (local / remote / "last steps" modes).
+- **Retire `register-gen.py`** once placement/drive lands (it is stale — see above — and is
+  being replaced, not backported to).
+- **arm64 / RPi template variant** (likely another `--template` + a tang HostSpec variant).
+
+---
+
 ## RPi / arm64 — NOT DONE (needs user input)
 
 There are **no rpiserv netboot configs** on the server yet — only the 3 lenservs are
@@ -228,11 +280,20 @@ documented way to create an arm64 host config is:
 ```bash
 bash /var/www/html/cloud-init/scripts/register-len-server.sh <hostname> <mac> <ip> arm64
 ```
-To bring rpiservs onto this system, we need their **MACs and target IPs**. The RPis are
-currently the **Tang servers** (172.16.2.45/.46/.47) and are typically SD-card based, so
-confirm intent before netboot-reinstalling them (reinstalling a Tang server breaks the
-t=2-of-3 unlock for everything until it's re-set-up — see tang-cold-start.sh / tang
-backup-restore scripts on the server).
+To bring rpiservs onto this system, we need their **MACs and target IPs**.
+
+RPi facts (confirmed by user 2026-06-21):
+- The RPis are the **Tang servers** (172.16.2.45/.46/.47) and **run off NVMe drives**
+  (NOT SD card).
+- **All three Tang servers mutually authenticate / depend on each other** — unlocking
+  any one requires the other two to be up (t=2-of-3 across the set). This is a
+  cold-start constraint: never reinstall more than one at a time, and ensure the other
+  two are healthy first. See `tang-cold-start.sh` / `tang-backup.sh` / `tang-restore.sh`
+  on the server.
+- **Intent:** a future **arm64 config for RPis** modeled on the lenserv flow (likely a
+  `--template` variant for the renderer). Current RPis should have **Tang key backups
+  shipped to the server** (verify `tang-backup.sh` is scheduled / has run). Not an
+  immediate task — revisit during/after the tool pivot.
 
 ---
 

--- a/src/autoinstall/host_spec.rs
+++ b/src/autoinstall/host_spec.rs
@@ -1,0 +1,123 @@
+// file: src/autoinstall/host_spec.rs
+// version: 1.0.0
+// guid: b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e
+// last-edited: 2026-06-21
+
+//! Per-host inputs for rendering an autoinstall `user-data`.
+//!
+//! A [`HostSpec`] holds the small set of values that differ between machines —
+//! everything else lives in the template. The fields map 1:1 to the template
+//! placeholders (see [`crate::autoinstall::render`]).
+
+/// The CockroachDB SQL/RPC port used in advertise/join strings on this fleet.
+pub const COCKROACH_PORT: u16 = 36357;
+
+/// The cluster's seed/server IP, always listed first in the join string.
+pub const COCKROACH_SERVER_IP: &str = "172.16.2.30";
+
+/// The Lenovo cluster member IPs, in canonical (ascending) order.
+pub const LENSERV_MEMBER_IPS: &[&str] = &["172.16.3.92", "172.16.3.94", "172.16.3.96"];
+
+/// The values that vary per host. Each maps to one template placeholder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostSpec {
+    /// `{{HOSTNAME}}` — e.g. `len-serv-003`.
+    pub hostname: String,
+    /// `{{NET_ADDRESS}}` — host IP **with CIDR**, e.g. `172.16.3.96/23`.
+    pub network_address: String,
+    /// `{{COCKROACH_ADVERTISE}}` — `ip:port`, e.g. `172.16.3.96:36357`.
+    pub cockroach_advertise: String,
+    /// `{{COCKROACH_JOIN}}` — comma-separated `ip:port` list (server first, then
+    /// the other members, excluding self).
+    pub cockroach_join: String,
+}
+
+impl HostSpec {
+    /// Strip the `/cidr` suffix from an address, returning the bare IP.
+    pub fn ip_without_cidr(address: &str) -> &str {
+        address.split('/').next().unwrap_or(address)
+    }
+
+    /// Build the CockroachDB advertise string for a host IP: `ip:port`.
+    pub fn compute_advertise(ip: &str, port: u16) -> String {
+        format!("{ip}:{port}")
+    }
+
+    /// Build the CockroachDB join string: the server first, then every member
+    /// except `self_ip`, preserving the given member order. Each entry is
+    /// `ip:port`.
+    pub fn compute_join(server_ip: &str, members: &[&str], self_ip: &str, port: u16) -> String {
+        std::iter::once(server_ip)
+            .chain(members.iter().copied().filter(|m| *m != self_ip))
+            .map(|ip| format!("{ip}:{port}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    /// Construct a spec for a Lenovo fleet host using the canonical server,
+    /// member set, and port. `network_address` carries the CIDR (e.g.
+    /// `172.16.3.96/23`); the bare IP is derived from it.
+    pub fn for_lenserv(hostname: impl Into<String>, network_address: impl Into<String>) -> Self {
+        let hostname = hostname.into();
+        let network_address = network_address.into();
+        let ip = Self::ip_without_cidr(&network_address).to_string();
+        let cockroach_advertise = Self::compute_advertise(&ip, COCKROACH_PORT);
+        let cockroach_join =
+            Self::compute_join(COCKROACH_SERVER_IP, LENSERV_MEMBER_IPS, &ip, COCKROACH_PORT);
+        Self {
+            hostname,
+            network_address,
+            cockroach_advertise,
+            cockroach_join,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ip_without_cidr_strips_suffix() {
+        assert_eq!(HostSpec::ip_without_cidr("172.16.3.96/23"), "172.16.3.96");
+        assert_eq!(HostSpec::ip_without_cidr("172.16.3.96"), "172.16.3.96");
+    }
+
+    #[test]
+    fn join_puts_server_first_and_excludes_self() {
+        // 003 = .96 → server, .92, .94
+        let join = HostSpec::compute_join(
+            COCKROACH_SERVER_IP,
+            LENSERV_MEMBER_IPS,
+            "172.16.3.96",
+            COCKROACH_PORT,
+        );
+        assert_eq!(
+            join,
+            "172.16.2.30:36357,172.16.3.92:36357,172.16.3.94:36357"
+        );
+    }
+
+    #[test]
+    fn for_lenserv_matches_known_hosts() {
+        // These are the exact strings verified against the live deployment.
+        let s1 = HostSpec::for_lenserv("len-serv-001", "172.16.3.92/23");
+        assert_eq!(s1.cockroach_advertise, "172.16.3.92:36357");
+        assert_eq!(
+            s1.cockroach_join,
+            "172.16.2.30:36357,172.16.3.94:36357,172.16.3.96:36357"
+        );
+
+        let s2 = HostSpec::for_lenserv("len-serv-002", "172.16.3.94/23");
+        assert_eq!(
+            s2.cockroach_join,
+            "172.16.2.30:36357,172.16.3.92:36357,172.16.3.96:36357"
+        );
+
+        let s3 = HostSpec::for_lenserv("len-serv-003", "172.16.3.96/23");
+        assert_eq!(
+            s3.cockroach_join,
+            "172.16.2.30:36357,172.16.3.92:36357,172.16.3.94:36357"
+        );
+    }
+}

--- a/src/autoinstall/mod.rs
+++ b/src/autoinstall/mod.rs
@@ -1,0 +1,17 @@
+// file: src/autoinstall/mod.rs
+// version: 1.0.0
+// guid: a0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c5d
+// last-edited: 2026-06-21
+
+//! Render subiquity autoinstall `user-data` from a template + per-host spec.
+//!
+//! This is the pivot away from the imperative ZFS installer: instead of driving
+//! an install command-by-command, the tool generates the proven, hand-verified
+//! len-serv-003 `user-data` parameterized per host, which the native Ubuntu
+//! installer (subiquity) then consumes.
+
+pub mod host_spec;
+pub mod render;
+
+pub use host_spec::HostSpec;
+pub use render::{default_template, render_user_data};

--- a/src/autoinstall/render.rs
+++ b/src/autoinstall/render.rs
@@ -1,0 +1,114 @@
+// file: src/autoinstall/render.rs
+// version: 1.0.0
+// guid: c2d3e4f5-a6b7-8c9d-0e1f-2a3b4c5d6e7f
+// last-edited: 2026-06-21
+
+//! Render a subiquity autoinstall `user-data` from a template + [`HostSpec`].
+//!
+//! The renderer is a deliberately dumb, data-driven text substitution. The
+//! template is the source of truth for everything that does NOT vary per host;
+//! the [`HostSpec`] supplies the bits that do. The default template
+//! (`templates/len-serv.user-data.tmpl`) is the hand-verified len-serv-003
+//! config with these placeholders:
+//!
+//! | Placeholder              | HostSpec field          | Example                                   |
+//! |--------------------------|-------------------------|-------------------------------------------|
+//! | `{{HOSTNAME}}`           | `hostname`              | `len-serv-003`                            |
+//! | `{{NET_ADDRESS}}`        | `network_address`       | `172.16.3.96/23`                          |
+//! | `{{COCKROACH_ADVERTISE}}`| `cockroach_advertise`   | `172.16.3.96:36357`                       |
+//! | `{{COCKROACH_JOIN}}`     | `cockroach_join`        | `172.16.2.30:36357,172.16.3.92:36357,...` |
+//!
+//! Rendering substitutes every known placeholder, then checks that no
+//! `{{...}}` token remains — an unfilled placeholder in a custom template is a
+//! hard error rather than something that silently ships to a machine.
+
+use crate::autoinstall::host_spec::HostSpec;
+use crate::error::AutoInstallError;
+use crate::Result;
+
+/// The embedded default template: the hand-verified len-serv-003 user-data.
+const DEFAULT_TEMPLATE: &str = include_str!("templates/len-serv.user-data.tmpl");
+
+/// Return the embedded default template (the len-serv-003 config).
+pub fn default_template() -> &'static str {
+    DEFAULT_TEMPLATE
+}
+
+/// Render `template` against `spec`, substituting all known placeholders.
+///
+/// Errors if any `{{...}}` placeholder remains after substitution (i.e. the
+/// template referenced something this renderer does not know how to fill).
+pub fn render_user_data(template: &str, spec: &HostSpec) -> Result<String> {
+    let rendered = template
+        .replace("{{HOSTNAME}}", &spec.hostname)
+        .replace("{{NET_ADDRESS}}", &spec.network_address)
+        .replace("{{COCKROACH_ADVERTISE}}", &spec.cockroach_advertise)
+        .replace("{{COCKROACH_JOIN}}", &spec.cockroach_join);
+
+    if let Some(leftover) = find_placeholder(&rendered) {
+        return Err(AutoInstallError::ConfigError(format!(
+            "template contains unknown placeholder '{leftover}' that the renderer cannot fill"
+        )));
+    }
+
+    Ok(rendered)
+}
+
+/// Find the first `{{...}}` placeholder in `s`, if any (returns the full token
+/// including braces).
+fn find_placeholder(s: &str) -> Option<String> {
+    let start = s.find("{{")?;
+    let rest = &s[start + 2..];
+    let end = rest.find("}}")?;
+    Some(format!("{{{{{}}}}}", &rest[..end]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The golden fixtures: rendering the default template with each host's
+    /// params must reproduce the exact bytes pulled from the live deployment.
+    const GOLDEN_001: &str = include_str!("../../tests/fixtures/golden/len-serv-001.user-data");
+    const GOLDEN_002: &str = include_str!("../../tests/fixtures/golden/len-serv-002.user-data");
+    const GOLDEN_003: &str = include_str!("../../tests/fixtures/golden/len-serv-003.user-data");
+
+    #[test]
+    fn renders_003_byte_for_byte() {
+        let spec = HostSpec::for_lenserv("len-serv-003", "172.16.3.96/23");
+        let out = render_user_data(default_template(), &spec).unwrap();
+        assert_eq!(out, GOLDEN_003);
+    }
+
+    #[test]
+    fn renders_001_byte_for_byte() {
+        let spec = HostSpec::for_lenserv("len-serv-001", "172.16.3.92/23");
+        let out = render_user_data(default_template(), &spec).unwrap();
+        assert_eq!(out, GOLDEN_001);
+    }
+
+    #[test]
+    fn renders_002_byte_for_byte() {
+        let spec = HostSpec::for_lenserv("len-serv-002", "172.16.3.94/23");
+        let out = render_user_data(default_template(), &spec).unwrap();
+        assert_eq!(out, GOLDEN_002);
+    }
+
+    #[test]
+    fn unfilled_placeholder_is_an_error() {
+        let custom = "hostname: {{HOSTNAME}}\nmystery: {{NOT_A_REAL_FIELD}}\n";
+        let spec = HostSpec::for_lenserv("x", "10.0.0.1/24");
+        let err = render_user_data(custom, &spec).unwrap_err();
+        assert!(
+            err.to_string().contains("{{NOT_A_REAL_FIELD}}"),
+            "error should name the offending placeholder, got: {err}"
+        );
+    }
+
+    #[test]
+    fn default_template_has_no_residual_after_full_render() {
+        let spec = HostSpec::for_lenserv("len-serv-003", "172.16.3.96/23");
+        let out = render_user_data(default_template(), &spec).unwrap();
+        assert!(find_placeholder(&out).is_none());
+    }
+}

--- a/src/autoinstall/templates/len-serv.user-data.tmpl
+++ b/src/autoinstall/templates/len-serv.user-data.tmpl
@@ -1,0 +1,226 @@
+#cloud-config
+autoinstall:
+  version: 1
+  refresh-installer:
+    update: true
+
+  identity:
+    realname: jdfalk Admin
+    hostname: {{HOSTNAME}}
+    username: jdfalk
+    password: "$6$rounds=500000$dPBsZ2xT/TgcZTlY$1L93FUt8OsRpcPS2Lg/LT/EKpnOaDvSY1IZ1bTEE70uCVtmI0gH44yYy1y4nMIlw3m0WqM6gd3fUx5aQfCkJ41"
+
+  ssh:
+    install-server: true
+    allow-pw: false
+    authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  oem:
+    install: false
+
+  packages:
+    - openssh-server
+    - vim
+    - htop
+    - jq
+    - parted
+    - gdisk
+    - cryptsetup
+    - lvm2
+    - dosfstools
+    - curl
+    - debootstrap
+    - clevis
+    - clevis-dracut
+    - clevis-luks
+    - zfs-dracut
+    - zsh
+    - git
+    - tmux
+    - screen
+    - rsync
+    - ethtool
+    - lshw
+    - rsyslog
+    - rsyslog-relp
+    - prometheus-node-exporter
+    - tpm2-tools
+    - zip
+    - unzip
+
+  user-data:
+    chpasswd:
+      expire: false
+    users:
+      - name: jdfalk
+        groups: [adm, sudo, cdrom, dip, lxd, docker]
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /usr/bin/zsh
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  storage:
+    layout:
+      name: lvm
+      match:
+        path: /dev/nvme0n1
+      sizing-policy: all
+      password: "TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS"
+
+  early-commands:
+    - systemctl start ssh
+    - echo 'ubuntu-server:ubuntu' | chpasswd
+
+  error-commands:
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && send_status_update "failed" 0 "Installation failed on {{HOSTNAME}} - uploading crash logs" && upload_logs /var/log/installer/syslog && upload_logs /var/log/installer/debug && upload_logs /var/log/cloud-init-output.log && upload_logs /var/log/cloud-init.log' || true
+
+  late-commands:
+    # Write the entire in-target setup script inline — no external download needed.
+    # YAML strips the leading indentation so the CHROOT_SETUP terminator lands at col 0,
+    # which is required for bash to recognise the end of the heredoc.
+    - |
+      cat > /target/tmp/chroot-setup.sh << 'CHROOT_SETUP'
+      #!/bin/bash
+      set -euo pipefail
+
+      # --- User / SSH ---
+      chown -R jdfalk:jdfalk /home/jdfalk 2>/dev/null || chown -R 1000:1000 /home/jdfalk
+      mkdir -p /home/jdfalk/.ssh
+      chmod 700 /home/jdfalk/.ssh
+      cat > /home/jdfalk/.ssh/authorized_keys << 'KEYS'
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+      KEYS
+      chmod 600 /home/jdfalk/.ssh/authorized_keys
+      chown -R jdfalk:jdfalk /home/jdfalk/.ssh
+      usermod -aG adm,sudo,cdrom,dip,lxd,docker jdfalk 2>/dev/null || true
+      echo 'jdfalk ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jdfalk
+      chmod 440 /etc/sudoers.d/jdfalk
+      chsh -s /usr/bin/zsh jdfalk
+
+      # --- Oh My Zsh ---
+      # stdin is not a tty in the chroot so the installer auto-enters unattended
+      # mode (RUNZSH=no CHSH=no OVERWRITE_CONFIRMATION=no) — no flags needed.
+      # su - sets HOME=/home/jdfalk so omz installs into the right directory.
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/ohmyzsh-install.sh \
+        -o /tmp/ohmyzsh-install.sh
+      su - jdfalk -s /bin/sh -c 'sh /tmp/ohmyzsh-install.sh'
+
+      # --- Timezone / hosts / rsyslog ---
+      ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
+      echo 'America/New_York' > /etc/timezone
+      cat >> /etc/hosts << 'HOSTS'
+      172.16.2.30 unimatrixzero.local unimatrixzero minio-01.local minio-01
+      172.16.2.45 rpi-serv-001.local rpi-serv-001 minio-02.local minio-02
+      172.16.2.46 rpi-serv-002.local rpi-serv-002 minio-03.local minio-03
+      172.16.2.47 rpi-serv-003.local rpi-serv-003 minio-04.local minio-04
+      HOSTS
+      cat > /etc/rsyslog.d/50-remote.conf << 'RSYSLOG'
+      module(load="omrelp")
+      *.*  action(type="omrelp" target="172.16.2.30" port="2514")
+      RSYSLOG
+      systemctl enable rsyslog
+
+      # --- Variables ---
+      cat > /root/variables.sh << 'VARS'
+      #!/bin/bash
+      DISK="/dev/nvme0n1"
+      TIMEZONE="America/New_York"
+      HOSTNAME="{{HOSTNAME}}"
+      REPORT_STATUS="/usr/local/bin/report-status.sh"
+      NET_ET_INTERFACE="enp1s0f0"
+      NET_ET_ADDRESS="{{NET_ADDRESS}}"
+      NET_ET_GATEWAY="172.16.2.1"
+      NET_ET_SEARCH="jf.local"
+      NET_ET_NAMESERVERS=("172.16.2.1" "1.1.1.1" "8.8.8.8")
+      COCKROACH_ADVERTISE="{{COCKROACH_ADVERTISE}}"
+      COCKROACH_JOIN="{{COCKROACH_JOIN}}"
+      COCKROACH_CACHE=".25"
+      COCKROACH_MAX_SQL=".25"
+      COCKROACH_LOCALITY="region=us,cluster-unit=lenovo"
+      TANG_URL1="http://172.16.2.45"
+      TANG_URL2="http://172.16.2.46"
+      TANG_URL3="http://172.16.2.47"
+      VARS
+      chmod +x /root/variables.sh
+
+      # --- report-status.sh and CockroachDB setup script ---
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/report-status.sh \
+        -o /usr/local/bin/report-status.sh
+      chmod +x /usr/local/bin/report-status.sh
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/setup_cockroachdb.sh \
+        -o /root/setup_cockroachdb.sh
+      chmod +x /root/setup_cockroachdb.sh
+
+      # --- rc.local: CockroachDB first-boot + TPM checkin ---
+      cat > /etc/rc.local << 'RCLOCAL'
+      #!/bin/bash
+      /root/setup_cockroachdb.sh >> /var/log/cockroach-setup.log 2>&1
+      HOSTNAME_VAL=$(hostname)
+      MAC=$(cat /sys/class/net/enp1s0f0/address 2>/dev/null || ip link | awk '/ether/{print $2}' | head -1)
+      SOURCE_IP=$(ip route get 1 | awk '{print $7; exit}')
+      TPM_EK=""
+      if command -v tpm2_readpublic &>/dev/null; then
+        TPM_EK=$(tpm2_readpublic -c 0x81010001 -f pem 2>/dev/null | sha256sum | cut -d' ' -f1 || true)
+      fi
+      curl -s -X POST http://172.16.2.30:25000/api/checkin \
+        -H "Content-Type: application/json" \
+        -d "{\"hostname\":\"${HOSTNAME_VAL}\",\"mac\":\"${MAC}\",\"ip\":\"${SOURCE_IP}\",\"tpm_ek\":\"${TPM_EK}\"}" || true
+      exit 0
+      RCLOCAL
+      chmod +x /etc/rc.local
+      systemctl enable rc-local
+
+      # --- Clevis / Tang LUKS binding ---
+      # blkid works here because curtin in-target binds /dev into the chroot.
+      LUKS_DEV=$(blkid -t TYPE=crypto_LUKS -o device | head -n1 || true)
+      if [[ -z "$LUKS_DEV" ]]; then
+        /usr/local/bin/report-status.sh failed 95 "No crypto_LUKS device found" || true
+        echo "ERROR: no crypto_LUKS device found" >&2
+        exit 1
+      fi
+      echo "Found LUKS device: $LUKS_DEV"
+      SSS='{"t":2,"pins":{"tang":[{"url":"http://172.16.2.45"},{"url":"http://172.16.2.46"},{"url":"http://172.16.2.47"}]}}'
+      if ! clevis luks list -d "$LUKS_DEV" 2>/dev/null | grep -qE 'sss|tang'; then
+        printf '%s' 'TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS' \
+          | clevis luks bind -y -k - -d "$LUKS_DEV" sss "$SSS"
+        echo "Clevis Tang binding complete"
+      else
+        echo "Clevis binding already present"
+      fi
+      clevis luks list -d "$LUKS_DEV"
+
+      # --- Dracut config for network-based Tang unlock ---
+      # rd.neednet=1 + ip=dhcp tells dracut to bring the NIC up in the initramfs
+      # so the Tang servers are reachable before LUKS is unlocked.
+      mkdir -p /etc/dracut.conf.d /etc/default/grub.d
+      cat > /etc/dracut.conf.d/clevis.conf << 'DRACUT'
+      add_dracutmodules+=" network "
+      kernel_cmdline="rd.neednet=1 ip=dhcp"
+      DRACUT
+      cat > /etc/default/grub.d/50-clevis-network.cfg << 'GRUBCFG'
+      GRUB_CMDLINE_LINUX="rd.neednet=1 ip=dhcp"
+      GRUBCFG
+      update-grub
+      dracut --regenerate-all --force
+      echo "Dracut initramfs rebuild complete"
+
+      /usr/local/bin/report-status.sh finished 100 "Installation complete on {{HOSTNAME}}" || true
+      CHROOT_SETUP
+
+    # Execute the script inside the installed system.
+    # curtin in-target handles /dev /proc /sys /run bind-mounts automatically.
+    - curtin in-target -- bash /tmp/chroot-setup.sh
+
+    # Reporting, boot-target flip, then idle until curtin reboots the machine.
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && upload_logs /var/log/installer/syslog && upload_logs /var/log/cloud-init-output.log && send_final_report' || true
+    - curl -s http://172.16.2.30:25000/api/flip/{{HOSTNAME}} || true
+    - sleep 900 || true

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 // file: src/cli/args.rs
-// version: 2.0.0
+// version: 2.1.0
 // guid: f6g7h8i9-j0k1-2345-6789-012345fghijk
-// last-edited: 2026-06-20
+// last-edited: 2026-06-21
 
 //! Command line argument definitions
 
@@ -170,6 +170,24 @@ pub enum Commands {
             help = "Force installation even when not in live environment (use with caution)"
         )]
         force: bool,
+    },
+
+    /// Render a subiquity autoinstall user-data from the proven template + per-host values
+    RenderUserData {
+        #[arg(short = 'n', long, help = "Target hostname, e.g. len-serv-003")]
+        hostname: String,
+
+        #[arg(long, help = "Host IP address with CIDR, e.g. 172.16.3.96/23")]
+        address: String,
+
+        #[arg(
+            long,
+            help = "Path to a custom template file (defaults to the embedded len-serv template)"
+        )]
+        template: Option<String>,
+
+        #[arg(long, help = "Write rendered user-data here (defaults to stdout)")]
+        output: Option<String>,
     },
 }
 
@@ -592,6 +610,42 @@ mod tests {
                 assert!(!force);
             }
             _ => panic!("Expected LocalInstall command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parsing_render_user_data() {
+        // Arrange
+        let args = vec![
+            "ubuntu-autoinstall-agent",
+            "render-user-data",
+            "--hostname",
+            "len-serv-003",
+            "--address",
+            "172.16.3.96/23",
+            "--template",
+            "/tmp/custom.tmpl",
+            "--output",
+            "/tmp/out.user-data",
+        ];
+
+        // Act
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        // Assert
+        match cli.command {
+            Commands::RenderUserData {
+                hostname,
+                address,
+                template,
+                output,
+            } => {
+                assert_eq!(hostname, "len-serv-003");
+                assert_eq!(address, "172.16.3.96/23");
+                assert_eq!(template.as_deref(), Some("/tmp/custom.tmpl"));
+                assert_eq!(output.as_deref(), Some("/tmp/out.user-data"));
+            }
+            _ => panic!("Expected RenderUserData command"),
         }
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,7 +1,7 @@
 // file: src/cli/commands.rs
-// version: 2.0.0
+// version: 2.1.0
 // guid: g7h8i9j0-k1l2-3456-7890-123456ghijkl
-// last-edited: 2026-06-20
+// last-edited: 2026-06-21
 
 //! Command implementations for the CLI
 
@@ -638,6 +638,44 @@ fn prompt_for_root_password() -> Result<String> {
         .map_err(crate::error::AutoInstallError::IoError)?;
 
     Ok(password.trim().to_string())
+}
+
+/// Render a subiquity autoinstall `user-data` from the template + per-host values.
+///
+/// Uses the embedded len-serv template unless `--template` points at a custom
+/// file. Output goes to `output_path` if given, else stdout.
+pub async fn render_user_data_command(
+    hostname: &str,
+    address: &str,
+    template_path: Option<&str>,
+    output_path: Option<&str>,
+) -> Result<()> {
+    use crate::autoinstall::{default_template, render_user_data, HostSpec};
+
+    let template = match template_path {
+        Some(path) => {
+            std::fs::read_to_string(path).map_err(crate::error::AutoInstallError::IoError)?
+        }
+        None => default_template().to_string(),
+    };
+
+    let spec = HostSpec::for_lenserv(hostname, address);
+    let rendered = render_user_data(&template, &spec)?;
+
+    match output_path {
+        Some(path) => {
+            std::fs::write(path, &rendered).map_err(crate::error::AutoInstallError::IoError)?;
+            info!("Wrote rendered user-data for {hostname} to {path}");
+        }
+        None => {
+            print!("{rendered}");
+            std::io::stdout()
+                .flush()
+                .map_err(crate::error::AutoInstallError::IoError)?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // file: src/lib.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: d82472d1-7f0f-4eb4-b0a3-6e1547103eb4
+// last-edited: 2026-06-21
 
 //! # Ubuntu AutoInstall Agent
 //!
@@ -8,6 +9,7 @@
 //! This system provides zero manual intervention deployment using VM-based golden
 //! images that can be deployed via SSH or netboot.
 
+pub mod autoinstall;
 pub mod cli;
 pub mod config;
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // file: src/main.rs
-// version: 2.0.0
+// version: 2.1.0
 // guid: h8i9j0k1-l2m3-4567-8901-234567hijklm
-// last-edited: 2026-06-20
+// last-edited: 2026-06-21
 
 //! Ubuntu AutoInstall Agent - Main entry point
 
@@ -119,6 +119,20 @@ async fn main() -> Result<()> {
                     hold_on_failure,
                     pause_after_storage,
                     force,
+                )
+                .await
+            }
+            ubuntu_autoinstall_agent::cli::args::Commands::RenderUserData {
+                hostname,
+                address,
+                template,
+                output,
+            } => {
+                render_user_data_command(
+                    &hostname,
+                    &address,
+                    template.as_deref(),
+                    output.as_deref(),
                 )
                 .await
             }

--- a/tests/fixtures/golden/len-serv-001.user-data
+++ b/tests/fixtures/golden/len-serv-001.user-data
@@ -1,0 +1,226 @@
+#cloud-config
+autoinstall:
+  version: 1
+  refresh-installer:
+    update: true
+
+  identity:
+    realname: jdfalk Admin
+    hostname: len-serv-001
+    username: jdfalk
+    password: "$6$rounds=500000$dPBsZ2xT/TgcZTlY$1L93FUt8OsRpcPS2Lg/LT/EKpnOaDvSY1IZ1bTEE70uCVtmI0gH44yYy1y4nMIlw3m0WqM6gd3fUx5aQfCkJ41"
+
+  ssh:
+    install-server: true
+    allow-pw: false
+    authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  oem:
+    install: false
+
+  packages:
+    - openssh-server
+    - vim
+    - htop
+    - jq
+    - parted
+    - gdisk
+    - cryptsetup
+    - lvm2
+    - dosfstools
+    - curl
+    - debootstrap
+    - clevis
+    - clevis-dracut
+    - clevis-luks
+    - zfs-dracut
+    - zsh
+    - git
+    - tmux
+    - screen
+    - rsync
+    - ethtool
+    - lshw
+    - rsyslog
+    - rsyslog-relp
+    - prometheus-node-exporter
+    - tpm2-tools
+    - zip
+    - unzip
+
+  user-data:
+    chpasswd:
+      expire: false
+    users:
+      - name: jdfalk
+        groups: [adm, sudo, cdrom, dip, lxd, docker]
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /usr/bin/zsh
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  storage:
+    layout:
+      name: lvm
+      match:
+        path: /dev/nvme0n1
+      sizing-policy: all
+      password: "TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS"
+
+  early-commands:
+    - systemctl start ssh
+    - echo 'ubuntu-server:ubuntu' | chpasswd
+
+  error-commands:
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && send_status_update "failed" 0 "Installation failed on len-serv-001 - uploading crash logs" && upload_logs /var/log/installer/syslog && upload_logs /var/log/installer/debug && upload_logs /var/log/cloud-init-output.log && upload_logs /var/log/cloud-init.log' || true
+
+  late-commands:
+    # Write the entire in-target setup script inline — no external download needed.
+    # YAML strips the leading indentation so the CHROOT_SETUP terminator lands at col 0,
+    # which is required for bash to recognise the end of the heredoc.
+    - |
+      cat > /target/tmp/chroot-setup.sh << 'CHROOT_SETUP'
+      #!/bin/bash
+      set -euo pipefail
+
+      # --- User / SSH ---
+      chown -R jdfalk:jdfalk /home/jdfalk 2>/dev/null || chown -R 1000:1000 /home/jdfalk
+      mkdir -p /home/jdfalk/.ssh
+      chmod 700 /home/jdfalk/.ssh
+      cat > /home/jdfalk/.ssh/authorized_keys << 'KEYS'
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+      KEYS
+      chmod 600 /home/jdfalk/.ssh/authorized_keys
+      chown -R jdfalk:jdfalk /home/jdfalk/.ssh
+      usermod -aG adm,sudo,cdrom,dip,lxd,docker jdfalk 2>/dev/null || true
+      echo 'jdfalk ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jdfalk
+      chmod 440 /etc/sudoers.d/jdfalk
+      chsh -s /usr/bin/zsh jdfalk
+
+      # --- Oh My Zsh ---
+      # stdin is not a tty in the chroot so the installer auto-enters unattended
+      # mode (RUNZSH=no CHSH=no OVERWRITE_CONFIRMATION=no) — no flags needed.
+      # su - sets HOME=/home/jdfalk so omz installs into the right directory.
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/ohmyzsh-install.sh \
+        -o /tmp/ohmyzsh-install.sh
+      su - jdfalk -s /bin/sh -c 'sh /tmp/ohmyzsh-install.sh'
+
+      # --- Timezone / hosts / rsyslog ---
+      ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
+      echo 'America/New_York' > /etc/timezone
+      cat >> /etc/hosts << 'HOSTS'
+      172.16.2.30 unimatrixzero.local unimatrixzero minio-01.local minio-01
+      172.16.2.45 rpi-serv-001.local rpi-serv-001 minio-02.local minio-02
+      172.16.2.46 rpi-serv-002.local rpi-serv-002 minio-03.local minio-03
+      172.16.2.47 rpi-serv-003.local rpi-serv-003 minio-04.local minio-04
+      HOSTS
+      cat > /etc/rsyslog.d/50-remote.conf << 'RSYSLOG'
+      module(load="omrelp")
+      *.*  action(type="omrelp" target="172.16.2.30" port="2514")
+      RSYSLOG
+      systemctl enable rsyslog
+
+      # --- Variables ---
+      cat > /root/variables.sh << 'VARS'
+      #!/bin/bash
+      DISK="/dev/nvme0n1"
+      TIMEZONE="America/New_York"
+      HOSTNAME="len-serv-001"
+      REPORT_STATUS="/usr/local/bin/report-status.sh"
+      NET_ET_INTERFACE="enp1s0f0"
+      NET_ET_ADDRESS="172.16.3.92/23"
+      NET_ET_GATEWAY="172.16.2.1"
+      NET_ET_SEARCH="jf.local"
+      NET_ET_NAMESERVERS=("172.16.2.1" "1.1.1.1" "8.8.8.8")
+      COCKROACH_ADVERTISE="172.16.3.92:36357"
+      COCKROACH_JOIN="172.16.2.30:36357,172.16.3.94:36357,172.16.3.96:36357"
+      COCKROACH_CACHE=".25"
+      COCKROACH_MAX_SQL=".25"
+      COCKROACH_LOCALITY="region=us,cluster-unit=lenovo"
+      TANG_URL1="http://172.16.2.45"
+      TANG_URL2="http://172.16.2.46"
+      TANG_URL3="http://172.16.2.47"
+      VARS
+      chmod +x /root/variables.sh
+
+      # --- report-status.sh and CockroachDB setup script ---
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/report-status.sh \
+        -o /usr/local/bin/report-status.sh
+      chmod +x /usr/local/bin/report-status.sh
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/setup_cockroachdb.sh \
+        -o /root/setup_cockroachdb.sh
+      chmod +x /root/setup_cockroachdb.sh
+
+      # --- rc.local: CockroachDB first-boot + TPM checkin ---
+      cat > /etc/rc.local << 'RCLOCAL'
+      #!/bin/bash
+      /root/setup_cockroachdb.sh >> /var/log/cockroach-setup.log 2>&1
+      HOSTNAME_VAL=$(hostname)
+      MAC=$(cat /sys/class/net/enp1s0f0/address 2>/dev/null || ip link | awk '/ether/{print $2}' | head -1)
+      SOURCE_IP=$(ip route get 1 | awk '{print $7; exit}')
+      TPM_EK=""
+      if command -v tpm2_readpublic &>/dev/null; then
+        TPM_EK=$(tpm2_readpublic -c 0x81010001 -f pem 2>/dev/null | sha256sum | cut -d' ' -f1 || true)
+      fi
+      curl -s -X POST http://172.16.2.30:25000/api/checkin \
+        -H "Content-Type: application/json" \
+        -d "{\"hostname\":\"${HOSTNAME_VAL}\",\"mac\":\"${MAC}\",\"ip\":\"${SOURCE_IP}\",\"tpm_ek\":\"${TPM_EK}\"}" || true
+      exit 0
+      RCLOCAL
+      chmod +x /etc/rc.local
+      systemctl enable rc-local
+
+      # --- Clevis / Tang LUKS binding ---
+      # blkid works here because curtin in-target binds /dev into the chroot.
+      LUKS_DEV=$(blkid -t TYPE=crypto_LUKS -o device | head -n1 || true)
+      if [[ -z "$LUKS_DEV" ]]; then
+        /usr/local/bin/report-status.sh failed 95 "No crypto_LUKS device found" || true
+        echo "ERROR: no crypto_LUKS device found" >&2
+        exit 1
+      fi
+      echo "Found LUKS device: $LUKS_DEV"
+      SSS='{"t":2,"pins":{"tang":[{"url":"http://172.16.2.45"},{"url":"http://172.16.2.46"},{"url":"http://172.16.2.47"}]}}'
+      if ! clevis luks list -d "$LUKS_DEV" 2>/dev/null | grep -qE 'sss|tang'; then
+        printf '%s' 'TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS' \
+          | clevis luks bind -y -k - -d "$LUKS_DEV" sss "$SSS"
+        echo "Clevis Tang binding complete"
+      else
+        echo "Clevis binding already present"
+      fi
+      clevis luks list -d "$LUKS_DEV"
+
+      # --- Dracut config for network-based Tang unlock ---
+      # rd.neednet=1 + ip=dhcp tells dracut to bring the NIC up in the initramfs
+      # so the Tang servers are reachable before LUKS is unlocked.
+      mkdir -p /etc/dracut.conf.d /etc/default/grub.d
+      cat > /etc/dracut.conf.d/clevis.conf << 'DRACUT'
+      add_dracutmodules+=" network "
+      kernel_cmdline="rd.neednet=1 ip=dhcp"
+      DRACUT
+      cat > /etc/default/grub.d/50-clevis-network.cfg << 'GRUBCFG'
+      GRUB_CMDLINE_LINUX="rd.neednet=1 ip=dhcp"
+      GRUBCFG
+      update-grub
+      dracut --regenerate-all --force
+      echo "Dracut initramfs rebuild complete"
+
+      /usr/local/bin/report-status.sh finished 100 "Installation complete on len-serv-001" || true
+      CHROOT_SETUP
+
+    # Execute the script inside the installed system.
+    # curtin in-target handles /dev /proc /sys /run bind-mounts automatically.
+    - curtin in-target -- bash /tmp/chroot-setup.sh
+
+    # Reporting, boot-target flip, then idle until curtin reboots the machine.
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && upload_logs /var/log/installer/syslog && upload_logs /var/log/cloud-init-output.log && send_final_report' || true
+    - curl -s http://172.16.2.30:25000/api/flip/len-serv-001 || true
+    - sleep 900 || true

--- a/tests/fixtures/golden/len-serv-002.user-data
+++ b/tests/fixtures/golden/len-serv-002.user-data
@@ -1,0 +1,226 @@
+#cloud-config
+autoinstall:
+  version: 1
+  refresh-installer:
+    update: true
+
+  identity:
+    realname: jdfalk Admin
+    hostname: len-serv-002
+    username: jdfalk
+    password: "$6$rounds=500000$dPBsZ2xT/TgcZTlY$1L93FUt8OsRpcPS2Lg/LT/EKpnOaDvSY1IZ1bTEE70uCVtmI0gH44yYy1y4nMIlw3m0WqM6gd3fUx5aQfCkJ41"
+
+  ssh:
+    install-server: true
+    allow-pw: false
+    authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  oem:
+    install: false
+
+  packages:
+    - openssh-server
+    - vim
+    - htop
+    - jq
+    - parted
+    - gdisk
+    - cryptsetup
+    - lvm2
+    - dosfstools
+    - curl
+    - debootstrap
+    - clevis
+    - clevis-dracut
+    - clevis-luks
+    - zfs-dracut
+    - zsh
+    - git
+    - tmux
+    - screen
+    - rsync
+    - ethtool
+    - lshw
+    - rsyslog
+    - rsyslog-relp
+    - prometheus-node-exporter
+    - tpm2-tools
+    - zip
+    - unzip
+
+  user-data:
+    chpasswd:
+      expire: false
+    users:
+      - name: jdfalk
+        groups: [adm, sudo, cdrom, dip, lxd, docker]
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /usr/bin/zsh
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  storage:
+    layout:
+      name: lvm
+      match:
+        path: /dev/nvme0n1
+      sizing-policy: all
+      password: "TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS"
+
+  early-commands:
+    - systemctl start ssh
+    - echo 'ubuntu-server:ubuntu' | chpasswd
+
+  error-commands:
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && send_status_update "failed" 0 "Installation failed on len-serv-002 - uploading crash logs" && upload_logs /var/log/installer/syslog && upload_logs /var/log/installer/debug && upload_logs /var/log/cloud-init-output.log && upload_logs /var/log/cloud-init.log' || true
+
+  late-commands:
+    # Write the entire in-target setup script inline — no external download needed.
+    # YAML strips the leading indentation so the CHROOT_SETUP terminator lands at col 0,
+    # which is required for bash to recognise the end of the heredoc.
+    - |
+      cat > /target/tmp/chroot-setup.sh << 'CHROOT_SETUP'
+      #!/bin/bash
+      set -euo pipefail
+
+      # --- User / SSH ---
+      chown -R jdfalk:jdfalk /home/jdfalk 2>/dev/null || chown -R 1000:1000 /home/jdfalk
+      mkdir -p /home/jdfalk/.ssh
+      chmod 700 /home/jdfalk/.ssh
+      cat > /home/jdfalk/.ssh/authorized_keys << 'KEYS'
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+      KEYS
+      chmod 600 /home/jdfalk/.ssh/authorized_keys
+      chown -R jdfalk:jdfalk /home/jdfalk/.ssh
+      usermod -aG adm,sudo,cdrom,dip,lxd,docker jdfalk 2>/dev/null || true
+      echo 'jdfalk ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jdfalk
+      chmod 440 /etc/sudoers.d/jdfalk
+      chsh -s /usr/bin/zsh jdfalk
+
+      # --- Oh My Zsh ---
+      # stdin is not a tty in the chroot so the installer auto-enters unattended
+      # mode (RUNZSH=no CHSH=no OVERWRITE_CONFIRMATION=no) — no flags needed.
+      # su - sets HOME=/home/jdfalk so omz installs into the right directory.
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/ohmyzsh-install.sh \
+        -o /tmp/ohmyzsh-install.sh
+      su - jdfalk -s /bin/sh -c 'sh /tmp/ohmyzsh-install.sh'
+
+      # --- Timezone / hosts / rsyslog ---
+      ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
+      echo 'America/New_York' > /etc/timezone
+      cat >> /etc/hosts << 'HOSTS'
+      172.16.2.30 unimatrixzero.local unimatrixzero minio-01.local minio-01
+      172.16.2.45 rpi-serv-001.local rpi-serv-001 minio-02.local minio-02
+      172.16.2.46 rpi-serv-002.local rpi-serv-002 minio-03.local minio-03
+      172.16.2.47 rpi-serv-003.local rpi-serv-003 minio-04.local minio-04
+      HOSTS
+      cat > /etc/rsyslog.d/50-remote.conf << 'RSYSLOG'
+      module(load="omrelp")
+      *.*  action(type="omrelp" target="172.16.2.30" port="2514")
+      RSYSLOG
+      systemctl enable rsyslog
+
+      # --- Variables ---
+      cat > /root/variables.sh << 'VARS'
+      #!/bin/bash
+      DISK="/dev/nvme0n1"
+      TIMEZONE="America/New_York"
+      HOSTNAME="len-serv-002"
+      REPORT_STATUS="/usr/local/bin/report-status.sh"
+      NET_ET_INTERFACE="enp1s0f0"
+      NET_ET_ADDRESS="172.16.3.94/23"
+      NET_ET_GATEWAY="172.16.2.1"
+      NET_ET_SEARCH="jf.local"
+      NET_ET_NAMESERVERS=("172.16.2.1" "1.1.1.1" "8.8.8.8")
+      COCKROACH_ADVERTISE="172.16.3.94:36357"
+      COCKROACH_JOIN="172.16.2.30:36357,172.16.3.92:36357,172.16.3.96:36357"
+      COCKROACH_CACHE=".25"
+      COCKROACH_MAX_SQL=".25"
+      COCKROACH_LOCALITY="region=us,cluster-unit=lenovo"
+      TANG_URL1="http://172.16.2.45"
+      TANG_URL2="http://172.16.2.46"
+      TANG_URL3="http://172.16.2.47"
+      VARS
+      chmod +x /root/variables.sh
+
+      # --- report-status.sh and CockroachDB setup script ---
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/report-status.sh \
+        -o /usr/local/bin/report-status.sh
+      chmod +x /usr/local/bin/report-status.sh
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/setup_cockroachdb.sh \
+        -o /root/setup_cockroachdb.sh
+      chmod +x /root/setup_cockroachdb.sh
+
+      # --- rc.local: CockroachDB first-boot + TPM checkin ---
+      cat > /etc/rc.local << 'RCLOCAL'
+      #!/bin/bash
+      /root/setup_cockroachdb.sh >> /var/log/cockroach-setup.log 2>&1
+      HOSTNAME_VAL=$(hostname)
+      MAC=$(cat /sys/class/net/enp1s0f0/address 2>/dev/null || ip link | awk '/ether/{print $2}' | head -1)
+      SOURCE_IP=$(ip route get 1 | awk '{print $7; exit}')
+      TPM_EK=""
+      if command -v tpm2_readpublic &>/dev/null; then
+        TPM_EK=$(tpm2_readpublic -c 0x81010001 -f pem 2>/dev/null | sha256sum | cut -d' ' -f1 || true)
+      fi
+      curl -s -X POST http://172.16.2.30:25000/api/checkin \
+        -H "Content-Type: application/json" \
+        -d "{\"hostname\":\"${HOSTNAME_VAL}\",\"mac\":\"${MAC}\",\"ip\":\"${SOURCE_IP}\",\"tpm_ek\":\"${TPM_EK}\"}" || true
+      exit 0
+      RCLOCAL
+      chmod +x /etc/rc.local
+      systemctl enable rc-local
+
+      # --- Clevis / Tang LUKS binding ---
+      # blkid works here because curtin in-target binds /dev into the chroot.
+      LUKS_DEV=$(blkid -t TYPE=crypto_LUKS -o device | head -n1 || true)
+      if [[ -z "$LUKS_DEV" ]]; then
+        /usr/local/bin/report-status.sh failed 95 "No crypto_LUKS device found" || true
+        echo "ERROR: no crypto_LUKS device found" >&2
+        exit 1
+      fi
+      echo "Found LUKS device: $LUKS_DEV"
+      SSS='{"t":2,"pins":{"tang":[{"url":"http://172.16.2.45"},{"url":"http://172.16.2.46"},{"url":"http://172.16.2.47"}]}}'
+      if ! clevis luks list -d "$LUKS_DEV" 2>/dev/null | grep -qE 'sss|tang'; then
+        printf '%s' 'TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS' \
+          | clevis luks bind -y -k - -d "$LUKS_DEV" sss "$SSS"
+        echo "Clevis Tang binding complete"
+      else
+        echo "Clevis binding already present"
+      fi
+      clevis luks list -d "$LUKS_DEV"
+
+      # --- Dracut config for network-based Tang unlock ---
+      # rd.neednet=1 + ip=dhcp tells dracut to bring the NIC up in the initramfs
+      # so the Tang servers are reachable before LUKS is unlocked.
+      mkdir -p /etc/dracut.conf.d /etc/default/grub.d
+      cat > /etc/dracut.conf.d/clevis.conf << 'DRACUT'
+      add_dracutmodules+=" network "
+      kernel_cmdline="rd.neednet=1 ip=dhcp"
+      DRACUT
+      cat > /etc/default/grub.d/50-clevis-network.cfg << 'GRUBCFG'
+      GRUB_CMDLINE_LINUX="rd.neednet=1 ip=dhcp"
+      GRUBCFG
+      update-grub
+      dracut --regenerate-all --force
+      echo "Dracut initramfs rebuild complete"
+
+      /usr/local/bin/report-status.sh finished 100 "Installation complete on len-serv-002" || true
+      CHROOT_SETUP
+
+    # Execute the script inside the installed system.
+    # curtin in-target handles /dev /proc /sys /run bind-mounts automatically.
+    - curtin in-target -- bash /tmp/chroot-setup.sh
+
+    # Reporting, boot-target flip, then idle until curtin reboots the machine.
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && upload_logs /var/log/installer/syslog && upload_logs /var/log/cloud-init-output.log && send_final_report' || true
+    - curl -s http://172.16.2.30:25000/api/flip/len-serv-002 || true
+    - sleep 900 || true

--- a/tests/fixtures/golden/len-serv-003.user-data
+++ b/tests/fixtures/golden/len-serv-003.user-data
@@ -1,0 +1,226 @@
+#cloud-config
+autoinstall:
+  version: 1
+  refresh-installer:
+    update: true
+
+  identity:
+    realname: jdfalk Admin
+    hostname: len-serv-003
+    username: jdfalk
+    password: "$6$rounds=500000$dPBsZ2xT/TgcZTlY$1L93FUt8OsRpcPS2Lg/LT/EKpnOaDvSY1IZ1bTEE70uCVtmI0gH44yYy1y4nMIlw3m0WqM6gd3fUx5aQfCkJ41"
+
+  ssh:
+    install-server: true
+    allow-pw: false
+    authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  oem:
+    install: false
+
+  packages:
+    - openssh-server
+    - vim
+    - htop
+    - jq
+    - parted
+    - gdisk
+    - cryptsetup
+    - lvm2
+    - dosfstools
+    - curl
+    - debootstrap
+    - clevis
+    - clevis-dracut
+    - clevis-luks
+    - zfs-dracut
+    - zsh
+    - git
+    - tmux
+    - screen
+    - rsync
+    - ethtool
+    - lshw
+    - rsyslog
+    - rsyslog-relp
+    - prometheus-node-exporter
+    - tpm2-tools
+    - zip
+    - unzip
+
+  user-data:
+    chpasswd:
+      expire: false
+    users:
+      - name: jdfalk
+        groups: [adm, sudo, cdrom, dip, lxd, docker]
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /usr/bin/zsh
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+
+  storage:
+    layout:
+      name: lvm
+      match:
+        path: /dev/nvme0n1
+      sizing-policy: all
+      password: "TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS"
+
+  early-commands:
+    - systemctl start ssh
+    - echo 'ubuntu-server:ubuntu' | chpasswd
+
+  error-commands:
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && send_status_update "failed" 0 "Installation failed on len-serv-003 - uploading crash logs" && upload_logs /var/log/installer/syslog && upload_logs /var/log/installer/debug && upload_logs /var/log/cloud-init-output.log && upload_logs /var/log/cloud-init.log' || true
+
+  late-commands:
+    # Write the entire in-target setup script inline — no external download needed.
+    # YAML strips the leading indentation so the CHROOT_SETUP terminator lands at col 0,
+    # which is required for bash to recognise the end of the heredoc.
+    - |
+      cat > /target/tmp/chroot-setup.sh << 'CHROOT_SETUP'
+      #!/bin/bash
+      set -euo pipefail
+
+      # --- User / SSH ---
+      chown -R jdfalk:jdfalk /home/jdfalk 2>/dev/null || chown -R 1000:1000 /home/jdfalk
+      mkdir -p /home/jdfalk/.ssh
+      chmod 700 /home/jdfalk/.ssh
+      cat > /home/jdfalk/.ssh/authorized_keys << 'KEYS'
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOq0x6/0fA+vn0EdNJvBuadOo4rZ1IwkCWbBOWCwvId5 jdfalk@Norn.lan
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP4PPvBh1cCMdh8S5Uqz/1cONHxhc78TfWLt0fx76B/G jdfalk@JohnathsMacBook.jf.local
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPghsb0DAzQX5LfLgb1Q11LJJhppTM1r093TWCTjxjdb eddsa-key-20220820
+      KEYS
+      chmod 600 /home/jdfalk/.ssh/authorized_keys
+      chown -R jdfalk:jdfalk /home/jdfalk/.ssh
+      usermod -aG adm,sudo,cdrom,dip,lxd,docker jdfalk 2>/dev/null || true
+      echo 'jdfalk ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jdfalk
+      chmod 440 /etc/sudoers.d/jdfalk
+      chsh -s /usr/bin/zsh jdfalk
+
+      # --- Oh My Zsh ---
+      # stdin is not a tty in the chroot so the installer auto-enters unattended
+      # mode (RUNZSH=no CHSH=no OVERWRITE_CONFIRMATION=no) — no flags needed.
+      # su - sets HOME=/home/jdfalk so omz installs into the right directory.
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/ohmyzsh-install.sh \
+        -o /tmp/ohmyzsh-install.sh
+      su - jdfalk -s /bin/sh -c 'sh /tmp/ohmyzsh-install.sh'
+
+      # --- Timezone / hosts / rsyslog ---
+      ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
+      echo 'America/New_York' > /etc/timezone
+      cat >> /etc/hosts << 'HOSTS'
+      172.16.2.30 unimatrixzero.local unimatrixzero minio-01.local minio-01
+      172.16.2.45 rpi-serv-001.local rpi-serv-001 minio-02.local minio-02
+      172.16.2.46 rpi-serv-002.local rpi-serv-002 minio-03.local minio-03
+      172.16.2.47 rpi-serv-003.local rpi-serv-003 minio-04.local minio-04
+      HOSTS
+      cat > /etc/rsyslog.d/50-remote.conf << 'RSYSLOG'
+      module(load="omrelp")
+      *.*  action(type="omrelp" target="172.16.2.30" port="2514")
+      RSYSLOG
+      systemctl enable rsyslog
+
+      # --- Variables ---
+      cat > /root/variables.sh << 'VARS'
+      #!/bin/bash
+      DISK="/dev/nvme0n1"
+      TIMEZONE="America/New_York"
+      HOSTNAME="len-serv-003"
+      REPORT_STATUS="/usr/local/bin/report-status.sh"
+      NET_ET_INTERFACE="enp1s0f0"
+      NET_ET_ADDRESS="172.16.3.96/23"
+      NET_ET_GATEWAY="172.16.2.1"
+      NET_ET_SEARCH="jf.local"
+      NET_ET_NAMESERVERS=("172.16.2.1" "1.1.1.1" "8.8.8.8")
+      COCKROACH_ADVERTISE="172.16.3.96:36357"
+      COCKROACH_JOIN="172.16.2.30:36357,172.16.3.92:36357,172.16.3.94:36357"
+      COCKROACH_CACHE=".25"
+      COCKROACH_MAX_SQL=".25"
+      COCKROACH_LOCALITY="region=us,cluster-unit=lenovo"
+      TANG_URL1="http://172.16.2.45"
+      TANG_URL2="http://172.16.2.46"
+      TANG_URL3="http://172.16.2.47"
+      VARS
+      chmod +x /root/variables.sh
+
+      # --- report-status.sh and CockroachDB setup script ---
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/report-status.sh \
+        -o /usr/local/bin/report-status.sh
+      chmod +x /usr/local/bin/report-status.sh
+      curl -fsSL http://172.16.2.30/cloud-init/scripts/setup_cockroachdb.sh \
+        -o /root/setup_cockroachdb.sh
+      chmod +x /root/setup_cockroachdb.sh
+
+      # --- rc.local: CockroachDB first-boot + TPM checkin ---
+      cat > /etc/rc.local << 'RCLOCAL'
+      #!/bin/bash
+      /root/setup_cockroachdb.sh >> /var/log/cockroach-setup.log 2>&1
+      HOSTNAME_VAL=$(hostname)
+      MAC=$(cat /sys/class/net/enp1s0f0/address 2>/dev/null || ip link | awk '/ether/{print $2}' | head -1)
+      SOURCE_IP=$(ip route get 1 | awk '{print $7; exit}')
+      TPM_EK=""
+      if command -v tpm2_readpublic &>/dev/null; then
+        TPM_EK=$(tpm2_readpublic -c 0x81010001 -f pem 2>/dev/null | sha256sum | cut -d' ' -f1 || true)
+      fi
+      curl -s -X POST http://172.16.2.30:25000/api/checkin \
+        -H "Content-Type: application/json" \
+        -d "{\"hostname\":\"${HOSTNAME_VAL}\",\"mac\":\"${MAC}\",\"ip\":\"${SOURCE_IP}\",\"tpm_ek\":\"${TPM_EK}\"}" || true
+      exit 0
+      RCLOCAL
+      chmod +x /etc/rc.local
+      systemctl enable rc-local
+
+      # --- Clevis / Tang LUKS binding ---
+      # blkid works here because curtin in-target binds /dev into the chroot.
+      LUKS_DEV=$(blkid -t TYPE=crypto_LUKS -o device | head -n1 || true)
+      if [[ -z "$LUKS_DEV" ]]; then
+        /usr/local/bin/report-status.sh failed 95 "No crypto_LUKS device found" || true
+        echo "ERROR: no crypto_LUKS device found" >&2
+        exit 1
+      fi
+      echo "Found LUKS device: $LUKS_DEV"
+      SSS='{"t":2,"pins":{"tang":[{"url":"http://172.16.2.45"},{"url":"http://172.16.2.46"},{"url":"http://172.16.2.47"}]}}'
+      if ! clevis luks list -d "$LUKS_DEV" 2>/dev/null | grep -qE 'sss|tang'; then
+        printf '%s' 'TANG_INITIAL_PASSPHRASE_REPLACE_WITH_CLEVIS' \
+          | clevis luks bind -y -k - -d "$LUKS_DEV" sss "$SSS"
+        echo "Clevis Tang binding complete"
+      else
+        echo "Clevis binding already present"
+      fi
+      clevis luks list -d "$LUKS_DEV"
+
+      # --- Dracut config for network-based Tang unlock ---
+      # rd.neednet=1 + ip=dhcp tells dracut to bring the NIC up in the initramfs
+      # so the Tang servers are reachable before LUKS is unlocked.
+      mkdir -p /etc/dracut.conf.d /etc/default/grub.d
+      cat > /etc/dracut.conf.d/clevis.conf << 'DRACUT'
+      add_dracutmodules+=" network "
+      kernel_cmdline="rd.neednet=1 ip=dhcp"
+      DRACUT
+      cat > /etc/default/grub.d/50-clevis-network.cfg << 'GRUBCFG'
+      GRUB_CMDLINE_LINUX="rd.neednet=1 ip=dhcp"
+      GRUBCFG
+      update-grub
+      dracut --regenerate-all --force
+      echo "Dracut initramfs rebuild complete"
+
+      /usr/local/bin/report-status.sh finished 100 "Installation complete on len-serv-003" || true
+      CHROOT_SETUP
+
+    # Execute the script inside the installed system.
+    # curtin in-target handles /dev /proc /sys /run bind-mounts automatically.
+    - curtin in-target -- bash /tmp/chroot-setup.sh
+
+    # Reporting, boot-target flip, then idle until curtin reboots the machine.
+    - curl -fsSL http://172.16.2.30/cloud-init/reporting.sh -o /tmp/reporting.sh
+    - bash -c 'source /tmp/reporting.sh && upload_logs /var/log/installer/syslog && upload_logs /var/log/cloud-init-output.log && send_final_report' || true
+    - curl -s http://172.16.2.30:25000/api/flip/len-serv-003 || true
+    - sleep 900 || true


### PR DESCRIPTION
## Summary
First slice of the pivot from "reimplement an installer" to "generate the proven subiquity autoinstall user-data."

- `src/autoinstall/{host_spec,render}.rs` — `HostSpec` + `render_user_data`; cockroach advertise/join derived per host (server first, members excluding self)
- Embedded default template = the hand-verified len-serv-003 user-data with per-host bits as placeholders (`{{HOSTNAME}}`, `{{NET_ADDRESS}}`, `{{COCKROACH_ADVERTISE}}`, `{{COCKROACH_JOIN}}`); overridable via `--template`. Unfilled placeholders are a hard error.
- `render-user-data` subcommand (stdout or `--output`)
- Golden tests assert byte-equality against `tests/fixtures/golden/len-serv-00{1,2,3}` pulled verbatim from the server — drift from the known-good is impossible
- Docs: renderer section + RPi facts (NVMe, mutual-auth Tang, future arm64)

The ZFS installer path is untouched (manual install on hold). `register-gen.py` on the server is stale and slated for replacement, not backport.

## Test plan
- `cargo test` — 165 pass (156 + 9 new), incl. byte-equal golden tests for 001/002/003
- Live CLI smoke test: ran the binary, diffed output against golden fixtures — identical
- clippy: zero new warnings (2 reported are pre-existing 8-arg handlers)

Note: golden tests prove the renderer *reproduces* the known-good artifacts. 003 is real-deployed truth; 001/002 fixtures are generated, not yet booted (that's a later slice + real deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)