### PR TITLE
feat(usb): auto-bootstrap USB installer + MAC-resolved config endpoint + static musl build

### DIFF
--- a/.github/workflows/musl-build.yml
+++ b/.github/workflows/musl-build.yml
@@ -1,0 +1,74 @@
+# file: .github/workflows/musl-build.yml
+# version: 1.0.0
+# guid: 6b2d9f04-3a7e-4c15-8d60-1f4e7a2c9b58
+
+# Static x86_64 musl release build of the agent.
+#
+# The USB auto-bootstrap (installer-image/nocloud/uaa-usb-bootstrap.sh) curls
+# this binary from the server at http://172.16.2.30/uaa/uaa-amd64, so it MUST
+# be fully static (musl) — the live installer environment and curtin in-target
+# chroots offer no guaranteed glibc.
+#
+# DEPLOY (human step): download the `uaa-amd64` artifact from this workflow run
+# (or build locally with scripts/build-musl.sh) and place it on the server:
+#   scp uaa-amd64 172.16.2.30:/tmp/ && \
+#   ssh 172.16.2.30 'sudo install -m 0755 /tmp/uaa-amd64 /var/www/html/uaa/uaa-amd64'
+
+name: Musl Static Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build-musl:
+    name: Build x86_64-unknown-linux-musl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools perl make
+
+      - name: Install Rust musl target
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: musl-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build static release binary
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+        run: cargo build --release --target x86_64-unknown-linux-musl
+
+      - name: Verify the binary is static
+        run: |
+          BIN=target/x86_64-unknown-linux-musl/release/ubuntu-autoinstall-agent
+          file "$BIN"
+          if ldd "$BIN" 2>&1 | grep -vq "not a dynamic executable\|statically linked"; then
+            echo "ERROR: binary is not static"; ldd "$BIN"; exit 1
+          fi
+
+      - name: Upload artifact (uaa-amd64)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: uaa-amd64
+          path: target/x86_64-unknown-linux-musl/release/ubuntu-autoinstall-agent
+          if-no-files-found: error

--- a/installer-image/nocloud/uaa-usb-bootstrap.sh
+++ b/installer-image/nocloud/uaa-usb-bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # file: installer-image/nocloud/uaa-usb-bootstrap.sh
-# version: 1.0.0
+# version: 1.1.0
 # guid: 9e4c7a20-1b5f-4d38-8a6e-2c0d9f471b63
 # last-edited: 2026-07-09
 #
@@ -65,6 +65,19 @@ finish() {
     esac
 }
 
+finish_failure() {
+    # Failure paths must NEVER reboot: uaa.on_done=reboot is baked into the USB
+    # cmdline, so a reboot lands right back in this bootstrap -> infinite
+    # fetch/wipe/reinstall loop. Coerce reboot->poweroff; only 'shell' (stay up
+    # for SSH inspection) is honored as-is.
+    local action="$1"
+    case "$action" in
+        shell) finish shell ;;
+        *)     [ "$action" = reboot ] && log "on_done=reboot ignored on FAILURE (would loop) — powering off"
+               finish poweroff ;;
+    esac
+}
+
 # Best-effort UEFI boot order: network entries first, ubuntu second, rest after.
 # Non-fatal by design — legacy-BIOS hosts (e.g. U1's legacy-OpROM IMSM array)
 # have no EFI variables and efibootmgr just fails; that's fine.
@@ -93,7 +106,7 @@ log "fetching agent binary: ${AGENT_URL}"
 if ! curl -fsSL --retry 5 --retry-delay 3 --max-time 120 "${AGENT_URL}" -o "${AGENT}"; then
     log "FAILED to fetch agent from ${AGENT_URL}"
     report_status failed "uaa-usb-bootstrap: could not fetch agent ${AGENT_URL}"
-    finish "${ON_DONE}"
+    finish_failure "${ON_DONE}"
     exit 1
 fi
 chmod +x "${AGENT}"
@@ -113,7 +126,7 @@ if ! curl -fsSL --retry 5 --retry-delay 3 --max-time 60 "${CONFIG_URL}" -o "${CO
     log "FAILED to fetch config from ${CONFIG_URL}"
     report_status failed "uaa-usb-bootstrap: could not fetch ${CONFIG_URL}"
     # A config-fetch failure must NOT loop-reinstall — halt for inspection.
-    finish "${ON_DONE}"
+    finish_failure "${ON_DONE}"
     exit 1
 fi
 
@@ -136,6 +149,6 @@ else
     report_status failed "uaa-usb-bootstrap: ${HOST} install failed (rc=${rc})"
     # Do NOT reboot-loop on a broken install; power off (or stay up with
     # uaa.on_done=shell) so an operator can inspect over SSH.
-    finish "${ON_DONE}"
+    finish_failure "${ON_DONE}"
     exit "${rc}"
 fi

--- a/installer-image/nocloud/uaa-usb-bootstrap.sh
+++ b/installer-image/nocloud/uaa-usb-bootstrap.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# file: installer-image/nocloud/uaa-usb-bootstrap.sh
+# version: 1.0.0
+# guid: 9e4c7a20-1b5f-4d38-8a6e-2c0d9f471b63
+# last-edited: 2026-07-09
+#
+# USB auto-bootstrap: turns the SSH-ready remastered Ubuntu Server USB into a
+# zero-touch installer, mirroring the netboot flow. Runs from the LIVE session
+# (cloud-init runcmd via make-ssh-ready-iso.sh --autoinstall) ONLY when the
+# kernel cmdline carries `uaa.autoinstall`. On boot it:
+#   1. curls the static agent binary from the server -> /usr/local/bin/uaa
+#   2. fetches the per-host InstallationConfig: uaa.config= from the cmdline if
+#      present, else the server's MAC-resolved endpoint (identity = wire MAC,
+#      same as the netboot cloud-init seed) -> /run/uaa-config.yaml
+#   3. runs `uaa install --config /run/uaa-config.yaml --report-url ...`
+#   4. on success, best-effort efibootmgr: BootOrder = network #1, ubuntu #2
+#   5. reports status and powers off (loop-safe). A config-fetch or install
+#      FAILURE never reboot-loops: poweroff, or shell if uaa.on_done=shell.
+#
+# Tunables (env, or uaa.* kernel cmdline tokens where noted):
+#   UAA_AGENT_URL           agent binary URL   (default http://172.16.2.30/uaa/uaa-amd64)
+#   UAA_CONFIG_RESOLVE_URL  MAC-resolved config endpoint
+#                           (default http://172.16.2.30:25000/autoinstall/uaa-config)
+#   UAA_REPORT_URL          install status webhook
+#                           (default http://172.16.2.30:25000/api/webhook)
+#   uaa.config=<url>        explicit per-host config URL (cmdline)
+#   uaa.on_done=poweroff|reboot|shell   post-run action (cmdline, default poweroff)
+
+set -uo pipefail
+
+AGENT=/usr/local/bin/uaa
+CONF=/run/uaa-config.yaml
+AGENT_URL="${UAA_AGENT_URL:-http://172.16.2.30/uaa/uaa-amd64}"
+REPORT_URL="${UAA_REPORT_URL:-http://172.16.2.30:25000/api/webhook}"
+REPORT_BASE="${UAA_REPORT_BASE:-http://172.16.2.30/cloud-init}"
+
+log() { echo "[uaa-usb-bootstrap] $*" | tee /dev/kmsg 2>/dev/null || echo "[uaa-usb-bootstrap] $*"; }
+
+# Parse a key=value token out of the kernel command line.
+cmdline_value() {
+    local key="$1" tok
+    for tok in $(cat /proc/cmdline); do
+        case "$tok" in
+            "${key}="*) printf '%s' "${tok#${key}=}"; return 0 ;;
+        esac
+    done
+    return 1
+}
+
+report_status() {
+    # Best-effort status ping; never fatal.
+    local state="$1" msg="$2"
+    curl -fsSL --max-time 10 "${REPORT_BASE}/reporting.sh" -o /run/reporting.sh 2>/dev/null \
+        && bash -c "source /run/reporting.sh && send_status_update '${state}' 0 '${msg}'" 2>/dev/null \
+        || true
+}
+
+finish() {
+    # $1 = poweroff|reboot|shell  (default from uaa.on_done, else poweroff)
+    local action="$1"
+    case "$action" in
+        reboot)  log "rebooting"; systemctl reboot ;;
+        shell)   log "leaving live session up for debugging (SSH-ready)"; ;;
+        *)       log "powering off (loop-safe)"; systemctl poweroff ;;
+    esac
+}
+
+# Best-effort UEFI boot order: network entries first, ubuntu second, rest after.
+# Non-fatal by design — legacy-BIOS hosts (e.g. U1's legacy-OpROM IMSM array)
+# have no EFI variables and efibootmgr just fails; that's fine.
+set_boot_order() {
+    command -v efibootmgr >/dev/null 2>&1 || { log "efibootmgr not present; skipping boot order"; return 0; }
+    local entries net ubuntu rest order
+    entries="$(efibootmgr 2>/dev/null)" || { log "efibootmgr unreadable (legacy BIOS?); skipping boot order"; return 0; }
+    net="$(echo "$entries"    | sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\)\*\{0,1\}[[:space:]].*\(PXE\|[Nn]etwork\|IPv[46]\).*/\1/p' | tr '\n' ',' )"
+    ubuntu="$(echo "$entries" | sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\)\*\{0,1\}[[:space:]][Uu]buntu.*/\1/p' | tr '\n' ',' )"
+    rest="$(echo "$entries"   | sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\)\*\{0,1\}[[:space:]].*/\1/p' | tr '\n' ',')"
+    # Compose net,ubuntu,then remaining entries (dedup, preserve order).
+    order="$(echo "${net}${ubuntu}${rest}" | tr ',' '\n' | grep -v '^$' | awk '!seen[$0]++' | paste -sd, -)"
+    [ -n "$order" ] || { log "no EFI boot entries found; skipping boot order"; return 0; }
+    if efibootmgr -o "$order" >/dev/null 2>&1; then
+        log "UEFI BootOrder set: $order (network first, ubuntu second)"
+    else
+        log "efibootmgr -o $order failed (non-fatal)"
+    fi
+    return 0
+}
+
+ON_DONE="$(cmdline_value uaa.on_done || echo poweroff)"
+
+# ── 1. fetch the static agent ────────────────────────────────────────────────
+log "fetching agent binary: ${AGENT_URL}"
+if ! curl -fsSL --retry 5 --retry-delay 3 --max-time 120 "${AGENT_URL}" -o "${AGENT}"; then
+    log "FAILED to fetch agent from ${AGENT_URL}"
+    report_status failed "uaa-usb-bootstrap: could not fetch agent ${AGENT_URL}"
+    finish "${ON_DONE}"
+    exit 1
+fi
+chmod +x "${AGENT}"
+
+# ── 2. fetch the per-host config (cmdline override, else MAC-resolved) ──────
+CONFIG_URL="$(cmdline_value uaa.config || true)"
+if [ -z "${CONFIG_URL}" ]; then
+    # No explicit per-host config on the cmdline (the USB is generic — unlike
+    # netboot there is no per-MAC cmdline). Use the server's MAC-resolved
+    # endpoint: it maps OUR wire MAC (from its ARP/NDP neighbor table) to the
+    # per-host uaa.yaml. One USB works for every machine.
+    CONFIG_URL="${UAA_CONFIG_RESOLVE_URL:-http://172.16.2.30:25000/autoinstall/uaa-config}"
+    log "no uaa.config= on cmdline; using MAC-resolved endpoint ${CONFIG_URL}"
+fi
+log "fetching per-host config: ${CONFIG_URL}"
+if ! curl -fsSL --retry 5 --retry-delay 3 --max-time 60 "${CONFIG_URL}" -o "${CONF}"; then
+    log "FAILED to fetch config from ${CONFIG_URL}"
+    report_status failed "uaa-usb-bootstrap: could not fetch ${CONFIG_URL}"
+    # A config-fetch failure must NOT loop-reinstall — halt for inspection.
+    finish "${ON_DONE}"
+    exit 1
+fi
+
+HOST="$(awk -F': *' '/^hostname:/ {print $2; exit}' "${CONF}" 2>/dev/null || echo unknown)"
+
+# ── 3. run the install ───────────────────────────────────────────────────────
+log "starting ZFS-on-LUKS install for host '${HOST}'"
+report_status running "uaa-usb-bootstrap: installing ${HOST}"
+
+if "${AGENT}" install --config "${CONF}" --report-url "${REPORT_URL}"; then
+    log "install completed OK for ${HOST}"
+    # ── 4. best-effort boot order (network #1, ubuntu #2) ───────────────────
+    set_boot_order
+    # ── 5. report + poweroff (loop-safe) ────────────────────────────────────
+    report_status success "uaa-usb-bootstrap: ${HOST} installed"
+    finish "${ON_DONE}"
+else
+    rc=$?
+    log "installer exited ${rc} for ${HOST}"
+    report_status failed "uaa-usb-bootstrap: ${HOST} install failed (rc=${rc})"
+    # Do NOT reboot-loop on a broken install; power off (or stay up with
+    # uaa.on_done=shell) so an operator can inspect over SSH.
+    finish "${ON_DONE}"
+    exit "${rc}"
+fi

--- a/installer-image/nocloud/user-data
+++ b/installer-image/nocloud/user-data
@@ -1,6 +1,6 @@
 #cloud-config
 # file: installer-image/nocloud/user-data
-# version: 1.0.0
+# version: 1.1.0
 # guid: 7c1a9e40-2b56-4d81-9f3a-6e0c2d4b8a10
 # last-edited: 2026-07-09
 #
@@ -12,6 +12,14 @@
 #     without needing root login enabled).
 # This is a live-session cloud-config (NO `autoinstall:` key) — it configures
 # the running installer environment; it does NOT trigger subiquity/curtin.
+#
+# USB auto-bootstrap: the SAME USB additionally auto-installs when (and ONLY
+# when) the kernel cmdline carries the `uaa.autoinstall` token (baked in by
+# make-ssh-ready-iso.sh --autoinstall). Without the token the runcmd gate below
+# is a no-op and the stick is plain SSH-ready for manual debugging. The
+# canonical bootstrap logic lives in uaa-usb-bootstrap.sh in this seed dir
+# (mapped to /nocloud on the ISO -> /cdrom/nocloud at runtime); write_files
+# only lands a thin launcher so the script stays single-source.
 
 ssh_pwauth: true
 
@@ -31,5 +39,28 @@ chpasswd:
   users:
     - {name: ubuntu-server, password: default, type: text}
 
+write_files:
+  - path: /usr/local/sbin/uaa-usb-bootstrap-launcher.sh
+    permissions: "0755"
+    owner: root:root
+    content: |
+      #!/bin/bash
+      # Thin launcher: run the canonical uaa-usb-bootstrap.sh from the ISO seed
+      # dir (single-source; do not duplicate the bootstrap logic here).
+      for d in /cdrom/nocloud /media/*/nocloud; do
+        if [ -f "${d}/uaa-usb-bootstrap.sh" ]; then
+          exec bash "${d}/uaa-usb-bootstrap.sh"
+        fi
+      done
+      echo "[uaa-usb-bootstrap-launcher] uaa-usb-bootstrap.sh not found on ISO" \
+        | tee /dev/kmsg 2>/dev/null
+      exit 1
+
 runcmd:
   - [systemctl, enable, --now, ssh]
+  # Auto-install ONLY when the uaa.autoinstall cmdline token is present
+  # (make-ssh-ready-iso.sh --autoinstall). Absent token = SSH-ready-only boot.
+  - |
+    if grep -qw uaa.autoinstall /proc/cmdline; then
+      /usr/local/sbin/uaa-usb-bootstrap-launcher.sh
+    fi

--- a/installer-image/uaa-autoinstall.sh
+++ b/installer-image/uaa-autoinstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # file: installer-image/uaa-autoinstall.sh
-# version: 1.1.0
+# version: 1.2.0
 # guid: 4b8e1d02-6f3a-4c77-9e21-5a0c8b6d1f34
 # last-edited: 2026-07-09
 #
@@ -52,6 +52,18 @@ finish() {
     esac
 }
 
+finish_failure() {
+    # Failure paths must NEVER reboot: with uaa.autoinstall still on the boot
+    # cmdline a reboot lands right back here -> infinite fetch/wipe/reinstall
+    # loop. Coerce reboot->poweroff; only 'shell' is honored as-is.
+    local action="$1"
+    case "$action" in
+        shell) finish shell ;;
+        *)     [ "$action" = reboot ] && log "on_done=reboot ignored on FAILURE (would loop) — powering off"
+               finish poweroff ;;
+    esac
+}
+
 ON_DONE="$(cmdline_value uaa.on_done || echo poweroff)"
 
 CONFIG_URL="$(cmdline_value uaa.config || true)"
@@ -71,7 +83,7 @@ if ! curl -fsSL --retry 5 --retry-delay 3 --max-time 60 "${CONFIG_URL}" -o "${CO
     log "FAILED to fetch config from ${CONFIG_URL}"
     report_status failed "uaa-autoinstall: could not fetch ${CONFIG_URL}"
     # A config-fetch failure should NOT loop-reinstall — halt for inspection.
-    finish "${ON_DONE:-poweroff}"
+    finish_failure "${ON_DONE:-poweroff}"
     exit 1
 fi
 
@@ -89,6 +101,6 @@ else
     report_status failed "uaa-autoinstall: ${HOST} install failed (rc=${rc})"
     # Do NOT reboot-loop on a broken install; power off (or drop to shell) so an
     # operator can inspect. Override with uaa.on_done=shell for interactive debug.
-    finish "${ON_DONE:-poweroff}"
+    finish_failure "${ON_DONE:-poweroff}"
     exit "${rc}"
 fi

--- a/scripts/autoinstall-agent.py
+++ b/scripts/autoinstall-agent.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # file: scripts/autoinstall-agent.py
-# version: 1.1.0
+# version: 1.2.0
 # guid: 7b6e4a2c-9f1d-4e8a-b3c6-2d5f8a1c9e07
-# last-edited: 2026-07-08
+# last-edited: 2026-07-09
 """
 autoinstall-agent: HTTP service on port 25000
 Handles webhook events, iPXE flips, cert issuance, MAC-based auth with approval,
@@ -372,6 +372,43 @@ class Handler(BaseHTTPRequestHandler):
             file_path = os.path.join(dir_path, filename)
             body = open(file_path, "rb").read() if os.path.isfile(file_path) else b""
             log(f"AUTOINSTALL {filename} -> {client_ip} (hexmac={hexmac})")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", len(body))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        # ════════════════════════════════════════════════════════════════════
+        # ── Auto-resolved installer config (USB / netboot bootstrap) ──────
+        # GET /autoinstall/uaa-config
+        # Serves the per-host InstallationConfig (<hexmac>/uaa.yaml) resolved
+        # the same MAC-as-identity way as the cloud-init seed above. Unlike the
+        # seed files, a MISSING uaa.yaml is a hard 404 (never an empty 200):
+        # the USB bootstrap must fail loudly at fetch time, not hand an empty
+        # config to `uaa install`. Place uaa.yaml with deploy-usb-configs.sh.
+        # ════════════════════════════════════════════════════════════════════
+        if path == "/autoinstall/uaa-config":
+            client_ip = self.client_address[0]
+            hexmac, dir_path = resolve_cloud_init_dir(client_ip)
+            if not hexmac:
+                log(f"UAA-CONFIG DENIED {client_ip} - no ARP/NDP neighbor entry")
+                self.send_response(404)
+                self.end_headers()
+                return
+            if not dir_path:
+                log(f"UAA-CONFIG DENIED {client_ip} (hexmac={hexmac}) - no cloud-init dir registered")
+                self.send_response(404)
+                self.end_headers()
+                return
+            file_path = os.path.join(dir_path, "uaa.yaml")
+            if not os.path.isfile(file_path):
+                log(f"UAA-CONFIG DENIED {client_ip} (hexmac={hexmac}) - no uaa.yaml placed")
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = open(file_path, "rb").read()
+            log(f"UAA-CONFIG -> {client_ip} (hexmac={hexmac})")
             self.send_response(200)
             self.send_header("Content-Type", "text/plain; charset=utf-8")
             self.send_header("Content-Length", len(body))

--- a/scripts/build-musl.sh
+++ b/scripts/build-musl.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# file: scripts/build-musl.sh
+# version: 1.0.0
+# guid: 8c5e1a37-4f92-4d6b-b8a0-6d3c9e2f7a14
+# last-edited: 2026-07-09
+#
+# Build the static x86_64 musl release binary of the agent on a Linux box
+# (e.g. the server 172.16.2.30 or any amd64 Ubuntu host). This is the binary
+# the USB auto-bootstrap curls at boot:
+#
+#   http://172.16.2.30/uaa/uaa-amd64   (UAA_AGENT_URL default in
+#                                       installer-image/nocloud/uaa-usb-bootstrap.sh)
+#
+# DEPLOY (human step) after building:
+#   sudo install -D -m 0755 \
+#     target/x86_64-unknown-linux-musl/release/ubuntu-autoinstall-agent \
+#     /var/www/html/uaa/uaa-amd64
+#
+# CI builds the same artifact: .github/workflows/musl-build.yml -> `uaa-amd64`.
+#
+# Requires: rustup, musl-tools (apt install musl-tools), perl, make
+# (the vendored-openssl in the ssh2 crate builds with musl-gcc).
+
+set -euo pipefail
+
+if [[ "$OSTYPE" != "linux-gnu"* ]]; then
+    echo "ERROR: musl static builds must run on Linux (use the server or CI)" >&2
+    exit 1
+fi
+
+command -v musl-gcc >/dev/null 2>&1 || { echo "ERROR: musl-gcc not found (apt install musl-tools)" >&2; exit 1; }
+rustup target list --installed | grep -q x86_64-unknown-linux-musl \
+    || rustup target add x86_64-unknown-linux-musl
+
+export CC_x86_64_unknown_linux_musl=musl-gcc
+cargo build --release --target x86_64-unknown-linux-musl
+
+BIN=target/x86_64-unknown-linux-musl/release/ubuntu-autoinstall-agent
+echo
+file "$BIN" || true
+if ldd "$BIN" 2>&1 | grep -vq "not a dynamic executable\|statically linked"; then
+    echo "ERROR: binary is not static" >&2
+    exit 1
+fi
+echo "OK: static binary at $BIN"
+echo "Deploy (human): sudo install -D -m 0755 '$BIN' /var/www/html/uaa/uaa-amd64"

--- a/scripts/deploy-usb-configs.sh
+++ b/scripts/deploy-usb-configs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# file: scripts/deploy-usb-configs.sh
+# version: 1.0.0
+# guid: 3f8a2c61-7d94-4b0e-a5c2-9e1f6b3d8a47
+# last-edited: 2026-07-09
+#
+# Place per-host InstallationConfig files where the autoinstall-agent's
+# MAC-resolved endpoint (GET /autoinstall/uaa-config) serves them:
+#
+#   <src-dir>/<host>.yaml  ->  /var/www/html/cloud-init/<hexmac>/uaa.yaml
+#
+# RUN THIS ON (or from) THE SERVER 172.16.2.30 as a HUMAN — the repo copies of
+# the configs carry `REPLACE_AT_PLACE_TIME` secret placeholders (luks_key,
+# root_password, tpm2_pin). Inject the real secrets into a staging copy first;
+# this script REFUSES to place any file that still contains the placeholder
+# (fail loud, place nothing for that host) so an unusable/secretless config can
+# never be served to a booting installer.
+#
+# Usage:
+#   scripts/deploy-usb-configs.sh [--src <dir>] [--dest <cloud-init base>] [host ...]
+#
+#   --src   directory of <host>.yaml files (default: examples/configs/install
+#           next to this script — NOTE these still hold placeholders; point
+#           --src at your secret-injected staging copies)
+#   --dest  cloud-init web root (default: /var/www/html/cloud-init)
+#   host…   subset of hosts to place (default: all known hosts)
+#
+# Exit status: 0 if every requested host was placed; 1 if any host was refused
+# (placeholder present, source missing, or unknown host).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="${SCRIPT_DIR}/../examples/configs/install"
+DEST_BASE="/var/www/html/cloud-init"
+PLACEHOLDER="REPLACE_AT_PLACE_TIME"
+
+# hostname -> MAC (hexmac derived below). These are the known fleet MACs.
+# (case-based lookup, not `declare -A`, so the script also runs under the
+# ancient bash 3.2 on macOS when driving the server remotely)
+KNOWN_HOSTS="len-serv-001 len-serv-002 len-serv-003 unimatrixone"
+mac_for_host() {
+    case "$1" in
+        len-serv-001) echo "6c:4b:90:bc:39:b3" ;;
+        len-serv-002) echo "6c:4b:90:bc:f8:a3" ;;
+        len-serv-003) echo "6c:4b:90:bc:f7:f4" ;;
+        unimatrixone) echo "ac:1f:6b:40:fc:e2" ;;
+        *) return 1 ;;
+    esac
+}
+
+HOSTS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --src)  SRC_DIR="$2";  shift 2 ;;
+        --dest) DEST_BASE="$2"; shift 2 ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*) echo "ERROR: unknown flag: $1" >&2; exit 1 ;;
+        *)  HOSTS+=("$1"); shift ;;
+    esac
+done
+[ ${#HOSTS[@]} -gt 0 ] || HOSTS=($KNOWN_HOSTS)
+
+fail=0
+for host in "${HOSTS[@]}"; do
+    if ! mac="$(mac_for_host "$host")"; then
+        echo "REFUSED $host: unknown host (add its MAC to mac_for_host)" >&2
+        fail=1
+        continue
+    fi
+    hexmac="${mac//:/}"
+    src="${SRC_DIR}/${host}.yaml"
+    if [ ! -f "$src" ]; then
+        echo "REFUSED $host: source not found: $src" >&2
+        fail=1
+        continue
+    fi
+    # HARD GATE: never place a config whose secrets were not injected.
+    if grep -q "$PLACEHOLDER" "$src"; then
+        echo "REFUSED $host: $src still contains ${PLACEHOLDER} — inject real" \
+             "secrets into a staging copy and pass it via --src" >&2
+        fail=1
+        continue
+    fi
+    dest_dir="${DEST_BASE}/${hexmac}"
+    mkdir -p "$dest_dir"
+    install -m 0644 "$src" "${dest_dir}/uaa.yaml"
+    echo "PLACED  $host ($mac) -> ${dest_dir}/uaa.yaml"
+done
+
+exit "$fail"

--- a/scripts/make-ssh-ready-iso.sh
+++ b/scripts/make-ssh-ready-iso.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # file: scripts/make-ssh-ready-iso.sh
-# version: 1.0.0
+# version: 1.1.0
 # guid: 5d2b7f18-9c04-4a6e-8b31-2f7a0c9d6e42
 # last-edited: 2026-07-09
 #
@@ -11,10 +11,18 @@
 # so the LIVE installer session boots with openssh-server on, user
 # `ubuntu-server` (known password + operator key) and NOPASSWD sudo — no manual
 # per-boot setup, and the `uaa install` agent can run every command as root over
-# SSH without root login. It does NOT autoinstall (no `autoinstall:` key).
+# SSH without root login. It does NOT subiquity-autoinstall (no `autoinstall:` key).
+#
+# OPT-IN auto-install (--autoinstall or UAA_AUTOINSTALL=1): additionally bakes
+# the `uaa.autoinstall` token (and optional `uaa.on_done=<action>`) into the
+# kernel cmdline. The seed's runcmd gate then runs uaa-usb-bootstrap.sh on boot:
+# fetch agent + per-host config from the server (MAC-resolved), install, power
+# off. WITHOUT the flag the stick stays SSH-ready-only (manual debug) — the
+# SAME seed serves both; only the cmdline token differs.
 #
 # Usage:
-#   scripts/make-ssh-ready-iso.sh <input.iso> [output.iso]
+#   scripts/make-ssh-ready-iso.sh [--autoinstall] [--on-done poweroff|reboot|shell] \
+#       <input.iso> [output.iso]
 #
 # Then write the output to the USB, e.g.:
 #   sudo dd if=<output.iso> of=/dev/sdX bs=4M status=progress conv=fsync
@@ -28,7 +36,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # running the script standalone (e.g. copied to /tmp on a target).
 SEED_DIR="${UAA_SEED_DIR:-${SCRIPT_DIR}/../installer-image/nocloud}"
 
-IN_ISO="${1:?usage: make-ssh-ready-iso.sh <input.iso> [output.iso]}"
+# Opt-in auto-install token baking (flag or env).
+AUTOINSTALL="${UAA_AUTOINSTALL:-0}"
+ON_DONE="${UAA_ON_DONE:-}"
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --autoinstall) AUTOINSTALL=1; shift ;;
+    --on-done)     ON_DONE="${2:?--on-done needs poweroff|reboot|shell}"; shift 2 ;;
+    -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)            echo "ERROR: unknown flag: $1"; exit 1 ;;
+    *)             POSITIONAL+=("$1"); shift ;;
+  esac
+done
+set -- "${POSITIONAL[@]:-}"
+case "$ON_DONE" in ""|poweroff|reboot|shell) ;; *) echo "ERROR: --on-done must be poweroff|reboot|shell"; exit 1 ;; esac
+
+IN_ISO="${1:?usage: make-ssh-ready-iso.sh [--autoinstall] [--on-done <action>] <input.iso> [output.iso]}"
 OUT_ISO="${2:-${IN_ISO%.iso}-ssh-ready.iso}"
 
 command -v xorriso >/dev/null 2>&1 || { echo "ERROR: xorriso not found (apt install xorriso / brew install xorriso)"; exit 1; }
@@ -70,9 +94,25 @@ patch_cfg() {
   sed -i -E 's#(linux(efi)?[[:space:]]+/casper/vmlinuz)#\1 ds=nocloud\\;s=/cdrom/nocloud/ autoinstall=0#' "$f"
   echo "  patched $f"
 }
+# Opt-in: bake the uaa.autoinstall token (+ optional uaa.on_done=) so the seed's
+# runcmd gate auto-runs uaa-usb-bootstrap.sh. Separate from patch_cfg so it is
+# idempotent on its own (re-running with --autoinstall on an already-SSH-ready
+# ISO only adds the token; re-running twice adds nothing).
+patch_autoinstall() {
+  local f="$1" tokens="uaa.autoinstall"
+  [ -n "$ON_DONE" ] && tokens="uaa.autoinstall uaa.on_done=${ON_DONE}"
+  if grep -q "uaa\.autoinstall" "$f"; then echo "  ($f already has uaa.autoinstall)"; return; fi
+  sed -i -E "s#(linux(efi)?[[:space:]]+/casper/vmlinuz)#\\1 ${tokens}#" "$f"
+  echo "  baked '${tokens}' into $f"
+}
 echo "== patching kernel cmdline =="
 patch_cfg "$WD/grub.cfg"
 [ "$HAVE_LOOPBACK" = 1 ] && patch_cfg "$WD/loopback.cfg"
+if [ "$AUTOINSTALL" = 1 ]; then
+  echo "== baking uaa.autoinstall token (opt-in) =="
+  patch_autoinstall "$WD/grub.cfg"
+  [ "$HAVE_LOOPBACK" = 1 ] && patch_autoinstall "$WD/loopback.cfg"
+fi
 
 echo "== repacking -> $OUT_ISO (preserving El Torito boot) =="
 MAPS=( -map "$WD/grub.cfg" /boot/grub/grub.cfg -map "$SEED_DIR" /nocloud )

--- a/scripts/make-ssh-ready-iso.sh
+++ b/scripts/make-ssh-ready-iso.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # file: scripts/make-ssh-ready-iso.sh
-# version: 1.1.0
+# version: 1.2.0
 # guid: 5d2b7f18-9c04-4a6e-8b31-2f7a0c9d6e42
 # last-edited: 2026-07-09
 #
@@ -85,13 +85,20 @@ if xorriso -osirrox on -indev "$IN_DEV" -extract /boot/grub/loopback.cfg "$WD/lo
   HAVE_LOOPBACK=1
 fi
 
+# Portable in-place sed: BSD/macOS sed rejects GNU's `-i -E` combo (-E gets
+# eaten as the -i backup suffix), so write via a temp file instead.
+sed_inplace() {
+  local expr="$1" f="$2"
+  sed -E "$expr" "$f" > "$f.sedtmp" && mv "$f.sedtmp" "$f"
+}
+
 # Add the cloud-init NoCloud datasource to every kernel line that boots casper.
 # The semicolon must be escaped for GRUB. Idempotent (skip if already present).
 patch_cfg() {
   local f="$1"
   if grep -q "ds=nocloud" "$f"; then echo "  ($f already patched)"; return; fi
   # Insert right after the vmlinuz path on each linux/linuxefi line.
-  sed -i -E 's#(linux(efi)?[[:space:]]+/casper/vmlinuz)#\1 ds=nocloud\\;s=/cdrom/nocloud/ autoinstall=0#' "$f"
+  sed_inplace 's#(linux(efi)?[[:space:]]+/casper/vmlinuz)#\1 ds=nocloud\\;s=/cdrom/nocloud/ autoinstall=0#' "$f"
   echo "  patched $f"
 }
 # Opt-in: bake the uaa.autoinstall token (+ optional uaa.on_done=) so the seed's
@@ -102,7 +109,7 @@ patch_autoinstall() {
   local f="$1" tokens="uaa.autoinstall"
   [ -n "$ON_DONE" ] && tokens="uaa.autoinstall uaa.on_done=${ON_DONE}"
   if grep -q "uaa\.autoinstall" "$f"; then echo "  ($f already has uaa.autoinstall)"; return; fi
-  sed -i -E "s#(linux(efi)?[[:space:]]+/casper/vmlinuz)#\\1 ${tokens}#" "$f"
+  sed_inplace "s#(linux(efi)?[[:space:]]+/casper/vmlinuz)#\\1 ${tokens}#" "$f"
   echo "  baked '${tokens}' into $f"
 }
 echo "== patching kernel cmdline =="

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,5 +1,5 @@
 // file: src/cli/args.rs
-// version: 2.5.0
+// version: 2.6.0
 // guid: f6g7h8i9-j0k1-2345-6789-012345fghijk
 // last-edited: 2026-07-09
 
@@ -116,7 +116,7 @@ pub enum Commands {
 
         #[arg(
             long,
-            help = "POST per-phase status to this webhook URL (e.g. http://172.16.2.30:25000/api/webhook); remote installs only"
+            help = "POST per-phase status to this webhook URL (e.g. http://172.16.2.30:25000/api/webhook)"
         )]
         report_url: Option<String>,
     },

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,5 +1,5 @@
 // file: src/cli/commands.rs
-// version: 2.4.0
+// version: 2.5.0
 // guid: g7h8i9j0-k1l2-3456-7890-123456ghijkl
 // last-edited: 2026-07-09
 
@@ -311,7 +311,9 @@ pub async fn ssh_install_command(
     // Load config from file or fall back to built-in default
     let config = if let Some(ref path) = config_path {
         info!("Loading installation config from {}", path);
-        InstallationConfig::from_yaml_file(path)?
+        let cfg = InstallationConfig::from_yaml_file(path)?;
+        validate_config_secrets(&cfg)?;
+        cfg
     } else {
         let hn = hostname.unwrap_or_else(|| "len-serv-003".to_string());
         if hn == "len-serv-003" {
@@ -367,14 +369,22 @@ pub async fn ssh_install_command(
     Ok(())
 }
 
-/// Install Ubuntu locally on the current live system
+/// Install Ubuntu locally on the current live system.
+///
+/// With `config_path` the full `InstallationConfig` YAML drives the install
+/// non-interactively (the USB/netboot auto-bootstrap path — stdin is /dev/null
+/// under cloud-init runcmd, so we must never prompt). Without it, the legacy
+/// interactive path auto-detects and prompts.
+#[allow(clippy::too_many_arguments)]
 pub async fn local_install_command(
     hostname: Option<String>,
+    config_path: Option<String>,
     investigate_only: bool,
     dry_run: bool,
     hold_on_failure: bool,
     pause_after_storage: bool,
     force: bool,
+    report_url: Option<String>,
 ) -> Result<()> {
     let hostname = hostname.unwrap_or_else(|| "ubuntu-local".to_string());
 
@@ -403,6 +413,7 @@ pub async fn local_install_command(
     }
 
     let mut installer = SshInstaller::new();
+    installer.set_report_url(report_url);
 
     // "Connect" to localhost (no-op for local)
     installer.connect_local().await?;
@@ -419,8 +430,16 @@ pub async fn local_install_command(
         return Ok(());
     }
 
-    // Create installation configuration for local system
-    let config = create_local_installation_config(&hostname, &system_info)?;
+    // Config-driven (non-interactive) or legacy interactive-detect path.
+    let config_driven = config_path.is_some();
+    let config = if let Some(ref path) = config_path {
+        info!("Loading installation config from {}", path);
+        let cfg = InstallationConfig::from_yaml_file(path)?;
+        validate_config_secrets(&cfg)?;
+        cfg
+    } else {
+        create_local_installation_config(&hostname, &system_info)?
+    };
 
     if dry_run {
         info!("DRY RUN: Would perform full ZFS+LUKS installation with config:");
@@ -451,13 +470,22 @@ pub async fn local_install_command(
         config.disk_device
     );
     println!("This is a DESTRUCTIVE operation that cannot be undone!");
-    println!("Press Ctrl+C to abort, or any other key to continue...");
 
-    // Wait for user confirmation
-    let mut input = String::new();
-    std::io::stdin()
-        .read_line(&mut input)
-        .map_err(crate::error::AutoInstallError::IoError)?;
+    if config_driven {
+        // Automation path (USB/netboot bootstrap): stdin is /dev/null under
+        // cloud-init runcmd — prompting would silently read EOF. The explicit
+        // --config file IS the operator's confirmation (same contract as the
+        // SSH install path).
+        info!("Config-driven install: proceeding without interactive confirmation");
+    } else {
+        println!("Press Ctrl+C to abort, or any other key to continue...");
+
+        // Wait for user confirmation
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(crate::error::AutoInstallError::IoError)?;
+    }
 
     info!("Starting full ZFS+LUKS Ubuntu installation locally...");
     installer
@@ -513,19 +541,14 @@ pub async fn install_command(
         }
         None => {
             local_install_command(
-                config_path
-                    .as_deref()
-                    .and_then(|p| {
-                        InstallationConfig::from_yaml_file(p)
-                            .ok()
-                            .map(|c| c.hostname)
-                    })
-                    .or_else(|| std::env::var("HOSTNAME").ok()),
+                std::env::var("HOSTNAME").ok(),
+                config_path,
                 investigate_only,
                 dry_run,
                 hold_on_failure,
                 pause_after_storage,
                 force,
+                report_url,
             )
             .await
         }
@@ -534,13 +557,38 @@ pub async fn install_command(
 
 /// Check if we're running in a live environment
 fn is_live_environment() -> bool {
-    // Check for common live environment indicators
+    // Check for common live environment indicators. Ubuntu Server live ISOs
+    // use casper (boot=casper on the cmdline, /run/casper at runtime), NOT
+    // Debian live-boot's /run/live / boot=live — check both families.
+    let cmdline = std::fs::read_to_string("/proc/cmdline").unwrap_or_default();
     std::path::Path::exists(std::path::Path::new("/run/live"))
         || std::path::Path::exists(std::path::Path::new("/lib/live"))
+        || std::path::Path::exists(std::path::Path::new("/run/casper"))
         || std::env::var("DEBIAN_FRONTEND").unwrap_or_default() == "noninteractive"
-        || std::fs::read_to_string("/proc/cmdline")
-            .unwrap_or_default()
-            .contains("boot=live")
+        || cmdline.contains("boot=live")
+        || cmdline.contains("boot=casper")
+        || cmdline.split_whitespace().any(|tok| tok == "casper")
+}
+
+/// Refuse to run a destructive install from a config whose secrets were never
+/// injected: an empty `luks_key` would LUKS-format the disk with an EMPTY
+/// passphrase, and a literal REPLACE_AT_PLACE_TIME means the placement step
+/// (deploy-usb-configs.sh secret injection) was skipped.
+fn validate_config_secrets(config: &InstallationConfig) -> Result<()> {
+    if config.luks_key.trim().is_empty() {
+        return Err(crate::error::AutoInstallError::ValidationError(
+            "Config luks_key is empty — refusing to LUKS-format with an empty passphrase"
+                .to_string(),
+        ));
+    }
+    if config.luks_key.contains("REPLACE_AT_PLACE_TIME")
+        || config.root_password.contains("REPLACE_AT_PLACE_TIME")
+    {
+        return Err(crate::error::AutoInstallError::ValidationError(
+            "Config still contains REPLACE_AT_PLACE_TIME placeholders — inject real secrets at placement time".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Create installation configuration for local system
@@ -634,7 +682,15 @@ fn prompt_for_luks_passphrase() -> Result<String> {
         .read_line(&mut passphrase)
         .map_err(crate::error::AutoInstallError::IoError)?;
 
-    Ok(passphrase.trim().to_string())
+    let passphrase = passphrase.trim().to_string();
+    if passphrase.is_empty() {
+        // stdin EOF (non-interactive) or bare Enter — never format with an
+        // empty passphrase.
+        return Err(crate::error::AutoInstallError::ValidationError(
+            "Empty LUKS passphrase (non-interactive stdin?) — use --config with a luks_key instead".to_string(),
+        ));
+    }
+    Ok(passphrase)
 }
 
 /// Prompt for root password
@@ -1042,11 +1098,13 @@ users:
 
         // Act
         let result = local_install_command(
-            hostname, true,  // investigate_only
+            hostname, None,  // config_path
+            true,  // investigate_only
             false, // dry_run
             false, // hold_on_failure
             false, // pause_after_storage
             false, // force
+            None,  // report_url
         )
         .await;
 
@@ -1062,16 +1120,45 @@ users:
 
         // Act
         let result = local_install_command(
-            hostname, false, // investigate_only
+            hostname, None,  // config_path
+            false, // investigate_only
             true,  // dry_run
             false, // hold_on_failure
             false, // pause_after_storage
             false, // force
+            None,  // report_url
         )
         .await;
 
         // Assert
         // Should fail since we're not running as root in test environment
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_config_secrets_rejects_empty_luks_key() {
+        let mut config = InstallationConfig::for_len_serv_003();
+        config.luks_key = "".to_string();
+        assert!(validate_config_secrets(&config).is_err());
+        config.luks_key = "   ".to_string();
+        assert!(validate_config_secrets(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_config_secrets_rejects_placeholder() {
+        let mut config = InstallationConfig::for_len_serv_003();
+        config.luks_key = "REPLACE_AT_PLACE_TIME".to_string();
+        assert!(validate_config_secrets(&config).is_err());
+        config.luks_key = "realkey".to_string();
+        config.root_password = "REPLACE_AT_PLACE_TIME".to_string();
+        assert!(validate_config_secrets(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_config_secrets_accepts_real_secrets() {
+        let mut config = InstallationConfig::for_len_serv_003();
+        config.luks_key = "a-real-passphrase".to_string();
+        config.root_password = "a-real-password".to_string();
+        assert!(validate_config_secrets(&config).is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // file: src/main.rs
-// version: 2.3.0
+// version: 2.4.0
 // guid: h8i9j0k1-l2m3-4567-8901-234567hijklm
-// last-edited: 2026-06-21
+// last-edited: 2026-07-09
 
 //! Ubuntu AutoInstall Agent - Main entry point
 
@@ -118,11 +118,13 @@ async fn main() -> Result<()> {
             } => {
                 local_install_command(
                     hostname,
+                    None, // config_path (use `install --config` for config-driven local installs)
                     investigate_only,
                     dry_run,
                     hold_on_failure,
                     pause_after_storage,
                     force,
+                    None, // report_url
                 )
                 .await
             }

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 # todo.md — ubuntu-autoinstall-agent
-# version: 1.7.0
+# version: 1.8.0
 # guid: todo0001-0000-0000-0000-000000000001
 # last-edited: 2026-07-09
 
@@ -87,11 +87,30 @@
   disk. grub-install currently makes `ubuntu` #1. Also flip the server's PXE target for
   the MAC to "boot local/proceed" so netboot doesn't reinstall. Prefer efibootmgr in the
   chroot over ipmitool-from-server for the EFI order.
-- [ ] **USB auto-bootstrap like netboot.** USB live env should, on boot, fetch its config
+- [x] **USB auto-bootstrap like netboot** (code shipped; deploy checklist below). USB live env,
+  on boot with the `uaa.autoinstall` cmdline token, fetches the static agent + its config
   BY MAC from the web util (172.16.2.30 autoinstall-agent.py, same as netboot) and
-  auto-run `uaa install`. On success (USB case) report back so boot order is fixed. Rebuild
-  the USB image, copy to the server for reuse, dd to the stick, test the full flow.
-  SCOPE: OS install only — NO cockroach post-install/join.
+  auto-runs `uaa install`, reports back, best-effort efibootmgr (network #1, ubuntu #2),
+  then powers off (loop-safe). Shipped: `/autoinstall/uaa-config` endpoint (repo mirror of
+  autoinstall-agent.py), `scripts/deploy-usb-configs.sh` (refuses REPLACE_AT_PLACE_TIME),
+  `installer-image/nocloud/uaa-usb-bootstrap.sh` + user-data runcmd gate,
+  `make-ssh-ready-iso.sh --autoinstall`. Without the token the same USB stays
+  SSH-ready-only. SCOPE: OS install only — NO cockroach post-install/join.
+
+  **Deploy checklist for the human (USB auto-bootstrap):**
+  1. Deploy the endpoint: `scp scripts/autoinstall-agent.py 172.16.2.30:/var/www/html/cloud-init/scripts/`
+     then `ssh 172.16.2.30 'sudo systemctl restart autoinstall-agent'`.
+  2. Inject real secrets into staging copies of `examples/configs/install/<host>.yaml`
+     (replace every REPLACE_AT_PLACE_TIME), then on the server run
+     `scripts/deploy-usb-configs.sh --src <staging-dir>` (places `<hexmac>/uaa.yaml`;
+     refuses any file still holding the placeholder).
+  3. Build + copy the static agent: `scripts/build-musl.sh` on a Linux box (or grab the
+     `uaa-amd64` CI artifact), then
+     `sudo install -D -m 0755 <bin> /var/www/html/uaa/uaa-amd64` on the server.
+  4. Rebuild the USB: `scripts/make-ssh-ready-iso.sh --autoinstall <stock.iso>`, then
+     `sudo dd if=<out.iso> of=/dev/sdX bs=4M status=progress conv=fsync`.
+  5. Test the full flow on one host: boot USB → agent+config fetched by MAC →
+     `uaa install` 7/7 → webhook report → poweroff; verify BootOrder + next boot from disk.
 - [ ] **Populate the RESET partition (p2, 4GiB ext4 — subiquity reset/recovery partition).**
   Currently created + formatted but empty. Idea (user 2026-07-09): put a copy of the
   bootable USB + the debootstrap tarball on it, and a GRUB "reset/recover" entry. The reset
@@ -144,8 +163,10 @@
   local mode using `LocalClient`.
 - [ ] **`PackageManager` installs `zsys`** — zsys is deprecated/removed in Ubuntu 24.04+. Remove it
   from package lists when release >= noble.
-- [ ] **Build doesn't produce a static musl binary by default** — for curtin in-target use, the binary
-  must run in a minimal chroot. Add `--target x86_64-unknown-linux-musl` build target and CI step.
+- [x] **Static musl binary** (shipped) — `scripts/build-musl.sh` + CI
+  `.github/workflows/musl-build.yml` build `x86_64-unknown-linux-musl` release and verify it
+  is static (artifact `uaa-amd64`). Human deploys it to the server at
+  `/var/www/html/uaa/uaa-amd64` (the `UAA_AGENT_URL` default the USB bootstrap curls).
 - [ ] **unimatrixone needs mdadm assembly in the target initramfs** — u1's disk is Intel IMSM/BIOS
   fake-RAID assembled by mdadm as `/dev/md126` (single ~885 GiB volume; NOT `/dev/sda`, which is a
   RAID *member*). The installer neither adds `mdadm` to the target package set (`packages.rs` only


### PR DESCRIPTION
## Summary

Implements the USB auto-bootstrap (cloud-init remaster of the stock Ubuntu Server ISO — netboot-equivalent flow) plus the static musl build that serves it, then fixes all 4 confirmed findings from a 10-agent adversarial review.

### USB auto-bootstrap
- **`GET /autoinstall/uaa-config`** (repo mirror of `scripts/autoinstall-agent.py`): serves per-host `<hexmac>/uaa.yaml` resolved by the client's wire MAC via ARP/NDP — same MAC-as-identity mechanism as the cloud-init seed. Missing `uaa.yaml` is a hard 404, never an empty 200.
- **`scripts/deploy-usb-configs.sh`**: human-run placement of `<host>.yaml` → `/var/www/html/cloud-init/<hexmac>/uaa.yaml`; refuses any file still containing `REPLACE_AT_PLACE_TIME`.
- **`installer-image/nocloud/uaa-usb-bootstrap.sh`**: fetch static agent (`http://172.16.2.30/uaa/uaa-amd64`) → fetch config (`uaa.config=` cmdline else MAC-resolved endpoint) → `uaa install --config --report-url` → best-effort efibootmgr (network #1, ubuntu #2) → report → poweroff (loop-safe).
- **`nocloud/user-data`**: `write_files` thin launcher + `runcmd` gated on the `uaa.autoinstall` cmdline token — the same USB is SSH-ready-only without the token.
- **`make-ssh-ready-iso.sh --autoinstall [--on-done …]`**: bakes the token into the GRUB cmdline; idempotent per token; portable sed (BSD/macOS + GNU).

### Rust: config-driven local install (was broken)
- `install --config` (local) now loads the full `InstallationConfig` and runs non-interactively; previously it discarded the config, prompted on `/dev/null` stdin, and would have LUKS-formatted with an **empty passphrase**.
- `validate_config_secrets()` refuses empty `luks_key` / `REPLACE_AT_PLACE_TIME` before any destructive phase (local + SSH paths).
- `is_live_environment()` now detects casper (Ubuntu live) sessions.
- Failure paths in both bootstrap scripts coerce `on_done=reboot` → poweroff (no reinstall loops).

### Static musl build
- `scripts/build-musl.sh` + `.github/workflows/musl-build.yml` → verified-static `uaa-amd64` artifact; human deploys to `/var/www/html/uaa/uaa-amd64`.

### todo.md
- USB auto-bootstrap + musl items checked off; human deploy checklist added.

## Test plan
- [x] `cargo test --lib --offline` — 237 passed (baseline 234 + 3 new secret-guard tests)
- [x] `cargo build --offline`, `cargo clippy` (no new warnings)
- [x] `bash -n` all scripts, `py_compile`, cloud-config YAML parse
- [x] deploy-script placeholder gate exercised live (refuse/place/unknown-host)
- [x] GRUB patch simulation on BSD sed incl. idempotent re-run
- [x] 10-agent adversarial review (3 lenses × refuting verifiers): 5 confirmed findings → all fixed; 2 refuted
- [ ] Hardware flow test (human, per todo.md deploy checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8fqXPVTDHZS6DMZEFimEJ