### PR TITLE
fix(installer): route all partition paths through suffix-aware partition_path helper

### DIFF
--- a/src/network/ssh_installer/disk_ops.rs
+++ b/src/network/ssh_installer/disk_ops.rs
@@ -1,10 +1,12 @@
 // file: src/network/ssh_installer/disk_ops.rs
-// version: 2.1.0
+// version: 2.2.0
 // guid: sshdisk1-2345-6789-abcd-ef0123456789
+// last-edited: 2026-07-10
 
 //! Disk operations for SSH installation
 
 use super::config::InstallationConfig;
+use super::partitions::partition_path;
 use crate::network::CommandExecutor;
 use crate::Result;
 use tracing::info;
@@ -317,12 +319,18 @@ impl<'a> DiskManager<'a> {
         // Format ESP and RESET partitions
         self.log_and_execute(
             "Formatting ESP (vfat)",
-            &format!("mkfs.vfat -F32 -n ESP {}p1", config.disk_device),
+            &format!(
+                "mkfs.vfat -F32 -n ESP {}",
+                partition_path(&config.disk_device, 1)
+            ),
         )
         .await?;
         self.log_and_execute(
             "Formatting RESET (ext4)",
-            &format!("mkfs.ext4 -F -L RESET {}p2", config.disk_device),
+            &format!(
+                "mkfs.ext4 -F -L RESET {}",
+                partition_path(&config.disk_device, 2)
+            ),
         )
         .await?;
 
@@ -337,16 +345,18 @@ impl<'a> DiskManager<'a> {
         self.log_and_execute(
             "Setting up LUKS encryption",
             &format!(
-                "echo '{}' | cryptsetup luksFormat --batch-mode {}p4",
-                config.luks_key, config.disk_device
+                "echo '{}' | cryptsetup luksFormat --batch-mode {}",
+                config.luks_key,
+                partition_path(&config.disk_device, 4)
             ),
         )
         .await?;
         self.log_and_execute(
             "Opening LUKS device",
             &format!(
-                "echo '{}' | cryptsetup open {}p4 luks",
-                config.luks_key, config.disk_device
+                "echo '{}' | cryptsetup open {} luks",
+                config.luks_key,
+                partition_path(&config.disk_device, 4)
             ),
         )
         .await?;
@@ -387,12 +397,12 @@ impl<'a> DiskManager<'a> {
 
     #[cfg(test)]
     fn build_mkfs_esp(disk: &str) -> String {
-        format!("mkfs.vfat -F32 -n ESP {}p1", disk)
+        format!("mkfs.vfat -F32 -n ESP {}", partition_path(disk, 1))
     }
 
     #[cfg(test)]
     fn build_mkfs_reset(disk: &str) -> String {
-        format!("mkfs.ext4 -F -L RESET {}p2", disk)
+        format!("mkfs.ext4 -F -L RESET {}", partition_path(disk, 2))
     }
 }
 

--- a/src/network/ssh_installer/installer.rs
+++ b/src/network/ssh_installer/installer.rs
@@ -1,7 +1,7 @@
 // file: src/network/ssh_installer/installer.rs
-// version: 2.4.0
+// version: 2.5.0
 // guid: sshins01-2345-6789-abcd-ef0123456789
-// last-edited: 2026-07-09
+// last-edited: 2026-07-10
 
 //! Main SSH/local installer orchestrating all installation phases.
 //!
@@ -12,6 +12,7 @@ use super::config::{InstallationConfig, SystemInfo};
 use super::disk_ops::DiskManager;
 use super::investigation::SystemInvestigator;
 use super::packages::PackageManager;
+use super::partitions::partition_path;
 use super::system_setup::SystemConfigurator;
 use super::zfs_ops::ZfsManager;
 use crate::network::{CommandExecutor, LocalClient, SshClient};
@@ -563,7 +564,8 @@ impl Default for SshInstaller {
 /// Build the list of manual commands that would run after storage setup.
 /// Used by pause-after-storage and tests.
 pub(super) fn build_next_commands_after_storage(config: &InstallationConfig) -> Vec<String> {
-    let esp_part = format!("{}p1", config.disk_device);
+    let esp_part = partition_path(&config.disk_device, 1);
+    let p4 = partition_path(&config.disk_device, 4);
     let release = config.debootstrap_release.as_deref().unwrap_or("resolute");
     vec![
         "mkdir -p /mnt/targetos/boot/efi".to_string(),
@@ -602,7 +604,7 @@ pub(super) fn build_next_commands_after_storage(config: &InstallationConfig) -> 
         // tpm2/fido2 stacks for the TPM2+PIN and YubiKey keyslots.
         "chroot /mnt/targetos bash -lc 'DEBIAN_FRONTEND=noninteractive apt install -y grub-efi-amd64 grub-efi-amd64-signed linux-image-generic shim-signed dracut dracut-network zfs-dracut zfsutils-linux zfs-zed efibootmgr cryptsetup dosfstools clevis clevis-luks clevis-dracut clevis-systemd systemd-cryptsetup tpm2-tools tpm-udev libfido2-1'".to_string(),
         "chroot /mnt/targetos bash -lc 'DEBIAN_FRONTEND=noninteractive apt purge -y os-prober || true'".to_string(),
-        format!("bash -lc 'UUID=$(blkid -s UUID -o value {d}p4 2>/dev/null || true); DEV=\"{d}p4\"; [ -n \"$UUID\" ] && DEV=\"/dev/disk/by-uuid/$UUID\"; echo \"luks $DEV none luks,discard,initramfs\" > /mnt/targetos/etc/crypttab'", d=config.disk_device),
+        format!("bash -lc 'UUID=$(blkid -s UUID -o value {p4} 2>/dev/null || true); DEV=\"{p4}\"; [ -n \"$UUID\" ] && DEV=\"/dev/disk/by-uuid/$UUID\"; echo \"luks $DEV none luks,discard,initramfs\" > /mnt/targetos/etc/crypttab'"),
         "chroot /mnt/targetos bash -lc 'dracut --regenerate-all --force'".to_string(),
         // --uefi-secure-boot lays down the signed shim chain (shimx64.efi ->
         // grubx64.efi) so Secure Boot can be enabled without reinstalling.

--- a/src/network/ssh_installer/mod.rs
+++ b/src/network/ssh_installer/mod.rs
@@ -1,7 +1,7 @@
 // file: src/network/ssh_installer/mod.rs
-// version: 1.1.0
+// version: 1.2.0
 // guid: sshmod01-2345-6789-abcd-ef0123456789
-// last-edited: 2026-07-09
+// last-edited: 2026-07-10
 
 //! SSH-based Ubuntu installation with ZFS and LUKS
 //!
@@ -13,6 +13,7 @@ pub mod disk_ops;
 pub mod installer;
 pub mod investigation;
 pub mod packages;
+pub mod partitions;
 pub mod status;
 pub mod system_setup;
 pub mod zfs_ops;

--- a/src/network/ssh_installer/partitions.rs
+++ b/src/network/ssh_installer/partitions.rs
@@ -1,0 +1,53 @@
+// file: src/network/ssh_installer/partitions.rs
+// version: 1.0.0
+// guid: 9e8ed319-c4c1-4e58-8e3b-dc5f8a4f869b
+// last-edited: 2026-07-10
+
+//! Suffix-aware partition path construction for the SSH installer.
+
+/// Build the path of partition `n` on `disk`, following the kernel naming
+/// rule: insert a `p` separator only when the disk name ends in a digit.
+/// `/dev/nvme0n1` -> `/dev/nvme0n1p3`, `/dev/md126` -> `/dev/md126p3`,
+/// `/dev/sda` -> `/dev/sda3`, `/dev/vda` -> `/dev/vda3`.
+pub fn partition_path(disk: &str, n: u32) -> String {
+    if disk.chars().last().is_some_and(|c| c.is_ascii_digit()) {
+        format!("{disk}p{n}")
+    } else {
+        format!("{disk}{n}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::partition_path;
+
+    #[test]
+    fn nvme_gets_p_suffix() {
+        assert_eq!(partition_path("/dev/nvme0n1", 3), "/dev/nvme0n1p3");
+    }
+
+    #[test]
+    fn md_device_gets_p_suffix() {
+        assert_eq!(partition_path("/dev/md126", 4), "/dev/md126p4");
+    }
+
+    #[test]
+    fn sda_no_p_suffix() {
+        assert_eq!(partition_path("/dev/sda", 1), "/dev/sda1");
+    }
+
+    #[test]
+    fn vda_no_p_suffix() {
+        assert_eq!(partition_path("/dev/vda", 4), "/dev/vda4");
+    }
+
+    #[test]
+    fn md_named_volume_ending_in_digit_gets_p_suffix() {
+        assert_eq!(partition_path("/dev/md/Volume0_0", 3), "/dev/md/Volume0_0p3");
+    }
+
+    #[test]
+    fn empty_disk_does_not_panic() {
+        assert_eq!(partition_path("", 1), "1");
+    }
+}

--- a/src/network/ssh_installer/system_setup.rs
+++ b/src/network/ssh_installer/system_setup.rs
@@ -1,7 +1,7 @@
 // file: src/network/ssh_installer/system_setup.rs
-// version: 2.8.0
+// version: 2.9.0
 // guid: sshsys01-2345-6789-abcd-ef0123456789
-// last-edited: 2026-07-09
+// last-edited: 2026-07-10
 
 //! System setup and configuration for SSH/local installation.
 //!
@@ -10,6 +10,7 @@
 //! reachable during initramfs boot for clevis-based LUKS unlock.
 
 use super::config::{InitramfsType, InstallationConfig};
+use super::partitions::partition_path;
 use crate::network::CommandExecutor;
 use crate::Result;
 use tracing::{info, warn};
@@ -43,12 +44,12 @@ impl<'a> SystemConfigurator<'a> {
     fn build_crypttab_entry(disk_device: &str, uuid_opt: Option<&str>) -> String {
         let dev = if let Some(uuid) = uuid_opt {
             if uuid.trim().is_empty() {
-                format!("{}p4", disk_device)
+                partition_path(disk_device, 4)
             } else {
                 format!("/dev/disk/by-uuid/{}", uuid.trim())
             }
         } else {
-            format!("{}p4", disk_device)
+            partition_path(disk_device, 4)
         };
         format!("luks {} none luks,discard,initramfs", dev)
     }
@@ -57,13 +58,14 @@ impl<'a> SystemConfigurator<'a> {
     fn choose_esp_partition(detected_output: &str, default_disk: &str) -> String {
         let part = detected_output.trim();
         if part.is_empty() {
-            format!("{}p1", default_disk)
+            partition_path(default_disk, 1)
         } else {
             part.to_string()
         }
     }
 
-    /// Detect the ESP partition path by GUID PARTTYPE; fallback to `${DISK}p1` if not found
+    /// Detect the ESP partition path by GUID PARTTYPE; fallback to partition 1 of the
+    /// configured disk (suffix-aware: nvme0n1p1 / sda1) if not found
     async fn detect_esp_partition_path(&mut self, default_disk: &str) -> Result<String> {
         let guid = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b";
         let cmd = Self::build_esp_detection_command(guid);
@@ -570,7 +572,7 @@ impl<'a> SystemConfigurator<'a> {
     pub async fn setup_luks_key_in_chroot(&mut self, config: &InstallationConfig) -> Result<()> {
         info!("Configuring LUKS crypttab in chroot");
 
-        let part = format!("{}p4", config.disk_device);
+        let part = partition_path(&config.disk_device, 4);
         let uuid_out = self
             .runner
             .execute_with_output(&format!(
@@ -881,7 +883,7 @@ impl<'a> SystemConfigurator<'a> {
 
         let luksdev = match uuid_opt {
             Some(u) if !u.trim().is_empty() => format!("/dev/disk/by-uuid/{}", u.trim()),
-            _ => format!("{}p4", config.disk_device),
+            _ => partition_path(&config.disk_device, 4),
         };
 
         // Seed contains the passphrase + PIN — write via unlogged execute + a
@@ -998,7 +1000,7 @@ mod tests {
     fn test_choose_esp_partition_falls_back_when_empty() {
         let detected = "  \n\t";
         let chosen = SystemConfigurator::choose_esp_partition(detected, "/dev/sda");
-        assert_eq!(chosen, "/dev/sdap1");
+        assert_eq!(chosen, "/dev/sda1");
     }
 
     #[test]
@@ -1023,13 +1025,13 @@ mod tests {
     #[test]
     fn test_build_crypttab_entry_without_uuid() {
         let e = SystemConfigurator::build_crypttab_entry("/dev/sda", None);
-        assert_eq!(e, "luks /dev/sdap4 none luks,discard,initramfs");
+        assert_eq!(e, "luks /dev/sda4 none luks,discard,initramfs");
     }
 
     #[test]
     fn test_build_crypttab_entry_with_empty_uuid() {
         let e = SystemConfigurator::build_crypttab_entry("/dev/sda", Some("  "));
-        assert_eq!(e, "luks /dev/sdap4 none luks,discard,initramfs");
+        assert_eq!(e, "luks /dev/sda4 none luks,discard,initramfs");
     }
 
     /// Extract the enabled dracut module list (the value of `add_dracutmodules+=`).

--- a/src/network/ssh_installer/zfs_ops.rs
+++ b/src/network/ssh_installer/zfs_ops.rs
@@ -1,11 +1,12 @@
 // file: src/network/ssh_installer/zfs_ops.rs
-// version: 2.3.0
+// version: 2.4.0
 // guid: sshzfs01-2345-6789-abcd-ef0123456789
-// last-edited: 2026-07-09
+// last-edited: 2026-07-10
 
 //! ZFS operations for SSH installation
 
 use super::config::InstallationConfig;
+use super::partitions::partition_path;
 use crate::network::CommandExecutor;
 use crate::Result;
 use std::collections::HashMap;
@@ -197,8 +198,8 @@ impl<'a> ZfsManager<'a> {
              -o compatibility=grub2 -o feature@livelist=enabled -o feature@zpool_checkpoint=enabled \
              -O devices=off -O acltype=posixacl -O xattr=sa -O compression=lz4 \
              -O normalization=formD -O relatime=on -O canmount=off -O mountpoint=none \
-             -m none -R /mnt/targetos bpool {}p3",
-            disk
+             -m none -R /mnt/targetos bpool {}",
+            partition_path(disk, 3)
         )
     }
 
@@ -378,7 +379,7 @@ mod tests {
         assert!(cmd.contains("zpool create"));
         // device should be present and appear at the end of the command
         assert!(cmd.contains(" bpool "));
-        assert!(cmd.ends_with("/dev/sdap3"));
+        assert!(cmd.ends_with("/dev/sda3"));
         assert!(cmd.contains(" -R /mnt/targetos "));
         assert!(cmd.contains("compatibility=grub2"));
         assert!(cmd.contains("cachefile=/etc/zfs/zpool.cache"));


### PR DESCRIPTION
/dev/sda- and /dev/vda-style disks got nonexistent /dev/sdapN paths because the
"p" separator was hardcoded at every format! site. The new
ssh_installer::partitions::partition_path(disk, n) appends "p" only when the
disk name ends in a digit (nvme0n1p3, md126p3 vs sda3, vda3). Converts every
production {}pN site in disk_ops/zfs_ops/system_setup/installer plus the two
cfg(test) mkfs builders, fixes the four tests that asserted the buggy sdapN
output, updates the stale ${DISK}p1 doc comment, and leaves utils/qemu.rs
untouched (loop devices always end in a digit). Unblocks the QEMU virtio gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
