### PR TITLE
feat(install-server): GET /api/health with agent-binary presence + serving docs

### DIFF
--- a/docs/netboot-autodeploy.md
+++ b/docs/netboot-autodeploy.md
@@ -1,7 +1,7 @@
 <!-- file: docs/netboot-autodeploy.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 9a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9 -->
-<!-- last-edited: 2026-06-21 -->
+<!-- last-edited: 2026-07-10 -->
 
 # Netboot Autodeploy — Source of Truth & Findings
 
@@ -102,12 +102,31 @@ Machine powers on
 ### autoinstall-agent HTTP service (port 25000 on the server)
 - `GET /api/registry` — all machines + status
 - `GET /api/events` — last 50 webhook events
+- `GET /api/health` — service liveness + registry/yubikey/tang counts + agent binary presence
 - `GET /api/approve/<mac>` — approve a pending machine
 - `GET /api/flip/<hostname>[?target=custom-autoinstall]` — set next boot target
   (default flips to local disk; `target=custom-autoinstall` forces reinstall)
 - `POST /api/checkin` — first-boot check-in (hostname/mac/ip/tpm_ek)
 - Logs: `/var/log/cockroach-autoinstall/{events.jsonl,registry.json,files/}`
 - CockroachDB CA: `/var/lib/cockroach-autoinstall/.cockroach-ca/{ca.crt,ca.key}`
+
+### uaa agent binary serving (/var/www/html/uaa/)
+nginx on plain `:80` serves `/var/www/html/uaa/uaa-amd64`, the compiled ubuntu-autoinstall-agent binary (built as `uaa-amd64` for x86_64-unknown-linux-musl). `installer-image/nocloud/uaa-usb-bootstrap.sh` downloads it during USB-boot autoinstall via the `UAA_AGENT_URL` environment variable (default `http://172.16.2.30/uaa/uaa-amd64`).
+
+**Build:** `scripts/build-musl.sh` on a Linux host (or use the CI artifact `uaa-amd64` from `musl-build.yml`).
+
+**Deploy (HUMAN step):**
+```bash
+# On 172.16.2.30, as root:
+sudo install -D -m 0755 target/x86_64-unknown-linux-musl/release/ubuntu-autoinstall-agent /var/www/html/uaa/uaa-amd64
+# (the /uaa/ directory does not exist until this first run)
+```
+
+**Verify deployment:**
+```bash
+curl -s http://172.16.2.30:25000/api/health | python3 -m json.tool
+# Look for "agent_binary": {"present": true, ...}
+```
 
 ### Force a reinstall of an existing host
 ```bash

--- a/scripts/autoinstall-agent.py
+++ b/scripts/autoinstall-agent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # file: scripts/autoinstall-agent.py
-# version: 1.3.0
+# version: 1.4.0
 # guid: 7b6e4a2c-9f1d-4e8a-b3c6-2d5f8a1c9e07
 # last-edited: 2026-07-10
 """
@@ -30,6 +30,7 @@ import subprocess, tempfile, shutil
 
 IPXE_BOOT_DIR = "/var/www/html/ipxe/boot"
 CLOUD_INIT_BASE = "/var/www/html/cloud-init"
+UAA_BINARY_PATH = "/var/www/html/uaa/uaa-amd64"
 LOG_DIR = "/var/log/cockroach-autoinstall"
 EVENTS_LOG = f"{LOG_DIR}/events.jsonl"
 FILES_DIR = f"{LOG_DIR}/files"
@@ -42,6 +43,19 @@ CA_KEY = "/var/lib/cockroach-autoinstall/.cockroach-ca/ca.key"
 
 os.makedirs(LOG_DIR, exist_ok=True)
 os.makedirs(FILES_DIR, exist_ok=True)
+
+def agent_binary_status(path):
+    """stat the served uaa binary. ABSENT file/dir is the normal, handled
+    case (build-musl.sh only PRINTS the deploy hint) — never an exception."""
+    info = {"path": path, "present": False, "size": None, "mtime": None}
+    try:
+        st = os.stat(path)
+    except OSError:
+        return info
+    info["present"] = True
+    info["size"] = st.st_size
+    info["mtime"] = datetime.utcfromtimestamp(st.st_mtime).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return info
 
 # ── Machine Registry ─────────────────────────────────────────────────────────
 def load_registry():
@@ -272,6 +286,19 @@ class Handler(BaseHTTPRequestHandler):
             save_registry(reg)
             log(f"DEREGISTERED {mac} ({hostname})")
             self.send_json(200, {"ok": True, "message": f"Deregistered {mac} ({hostname})"})
+            return
+
+        # ── Health / liveness ──
+        if path == "/api/health":
+            reg = load_registry()
+            self.send_json(200, {
+                "status": "ok",
+                "registry_hosts": len(reg),
+                "registry_approved": sum(1 for e in reg.values() if e.get("status") == "approved"),
+                "yubikeys": len(load_yk_registry()),
+                "tang_servers": len(load_tang_registry()),
+                "agent_binary": agent_binary_status(UAA_BINARY_PATH),
+            })
             return
 
         # ── Machine registry ──


### PR DESCRIPTION
Read-only liveness route: registry/yubikey/tang counts (0 when a registry file is
absent) and os.stat-based presence of /var/www/html/uaa/uaa-amd64 — absent dir is
the handled default since build-musl.sh only prints the deploy hint. Document the
nginx /uaa/ serving path, UAA_AGENT_URL bootstrap flow, and the human deploy steps
in docs/netboot-autodeploy.md. Mirror only; human deploys via scp + systemctl
restart autoinstall-agent.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
