### PR TITLE
feat(proto): CP-02 uaa-proto crate (tonic/prost via protox) + workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,23 @@ libc = "0.2"
 
 # Dev dependencies
 tokio-test = "0.4"
+
+# constellation deps (CP-02) — later crates reference these with workspace = true
+axum = "0.7"
+ed25519-dalek = "2.1"
+mdns-sd = "0.13"
+notify = "6.1"
+prost = "0.13"
+prost-types = "0.13"
+protox = "0.7"
+rcgen = "0.13"
+rust-embed = "8.5"
+rustls = "0.23"
+semver = "1.0"
+tokio-postgres = "0.7"
+tokio-rustls = "0.26"
+tonic = "0.12"
+tonic-build = "0.12"
+tower-http = { version = "0.6", features = ["fs"] }
+utoipa = "5.2"
+x509-parser = "0.16"

--- a/crates/uaa-proto/Cargo.toml
+++ b/crates/uaa-proto/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "uaa-proto"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generated gRPC/protobuf types for the uaa constellation (proto/uaa/**), compiled with protox"
+
+[dependencies]
+tonic = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+
+[build-dependencies]
+protox = { workspace = true }
+tonic-build = { workspace = true }

--- a/crates/uaa-proto/build.rs
+++ b/crates/uaa-proto/build.rs
@@ -1,0 +1,21 @@
+// file: crates/uaa-proto/build.rs
+// version: 1.0.0
+// guid: b1fd887b-4926-4509-b33d-ef1134a3b79f
+// last-edited: 2026-07-10
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let files = [
+        "../../proto/uaa/control/v1/control.proto",
+        "../../proto/uaa/enroll/v1/enroll.proto",
+        "../../proto/uaa/web/v1/web.proto",
+        "../../proto/uaa/pxe/v1/pxe.proto",
+        "../../proto/uaa/update/v1/update.proto",
+    ];
+    let fds = protox::compile(files, ["../../proto"])?;
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_fds(fds)?;
+    println!("cargo:rerun-if-changed=../../proto");
+    Ok(())
+}

--- a/crates/uaa-proto/src/lib.rs
+++ b/crates/uaa-proto/src/lib.rs
@@ -1,0 +1,84 @@
+// file: crates/uaa-proto/src/lib.rs
+// version: 1.0.0
+// guid: 691b3989-e011-4a23-986c-f2886a9707f3
+// last-edited: 2026-07-10
+
+//! Generated gRPC/protobuf types for the uaa constellation.
+//!
+//! Each module below re-exports the code protox + tonic-build generate from
+//! `proto/uaa/**` at build time (see `build.rs`). Generated code is never
+//! committed; it lives under `OUT_DIR`.
+
+pub mod control {
+    pub mod v1 {
+        tonic::include_proto!("uaa.control.v1");
+    }
+}
+
+pub mod enroll {
+    pub mod v1 {
+        tonic::include_proto!("uaa.enroll.v1");
+    }
+}
+
+pub mod web {
+    pub mod v1 {
+        tonic::include_proto!("uaa.web.v1");
+    }
+}
+
+pub mod pxe {
+    pub mod v1 {
+        tonic::include_proto!("uaa.pxe.v1");
+    }
+}
+
+pub mod update {
+    pub mod v1 {
+        tonic::include_proto!("uaa.update.v1");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn test_machine_roundtrip() {
+        let machine = control::v1::Machine {
+            mac: "aa:bb:cc:dd:ee:ff".to_string(),
+            boot_target: "install".to_string(),
+            consistent: true,
+            ..Default::default()
+        };
+
+        let mut buf = Vec::new();
+        machine.encode(&mut buf).expect("encode Machine");
+        let decoded = control::v1::Machine::decode(buf.as_slice()).expect("decode Machine");
+
+        assert_eq!(machine, decoded);
+    }
+
+    #[test]
+    fn test_manifest_min_version_field() {
+        let manifest = update::v1::Manifest {
+            binaries: vec![update::v1::BinaryEntry {
+                name: "uaa".to_string(),
+                version: "1.2.3".to_string(),
+                target: "x86_64-unknown-linux-musl".to_string(),
+                sha256: "deadbeef".to_string(),
+                sig: "sig".to_string(),
+                url: "https://example.invalid/uaa".to_string(),
+            }],
+            min_version: "1.2.3".to_string(),
+        };
+
+        let mut buf = Vec::new();
+        manifest.encode(&mut buf).expect("encode Manifest");
+        let decoded = update::v1::Manifest::decode(buf.as_slice()).expect("decode Manifest");
+
+        assert_eq!(decoded.min_version, "1.2.3");
+        assert_eq!(manifest, decoded);
+    }
+}

--- a/proto/uaa/control/v1/control.proto
+++ b/proto/uaa/control/v1/control.proto
@@ -1,0 +1,96 @@
+// file: proto/uaa/control/v1/control.proto
+// version: 1.0.0
+// guid: 9ba90d15-73be-4b6c-bb73-db3a0296a547
+// last-edited: 2026-07-10
+
+syntax = "proto3";
+
+package uaa.control.v1;
+
+// ControlService is the operator-facing control plane API: machine
+// approval/lifecycle, install event recording, and discovered-MAC intake.
+service ControlService {
+  rpc ApproveMachine(ApproveMachineRequest) returns (ApproveMachineResponse);
+  rpc GetMachine(GetMachineRequest) returns (Machine);
+  rpc ListMachines(ListMachinesRequest) returns (ListMachinesResponse);
+  rpc RecordInstallEvent(RecordInstallEventRequest) returns (Ack);
+  rpc ReinstallMachine(ReinstallMachineRequest) returns (ReinstallMachineResponse);
+  rpc UpsertDiscoveredMac(UpsertDiscoveredMacRequest) returns (Ack);
+}
+
+message ApproveMachineRequest {
+  string mac = 1;
+  string approved_by = 2;
+}
+
+message ApproveMachineResponse {
+  string saga_id = 1;
+  bool ok = 2;
+  string detail = 3;
+}
+
+message GetMachineRequest {
+  string mac = 1;
+}
+
+message ListMachinesRequest {}
+
+message ListMachinesResponse {
+  repeated Machine machines = 1;
+}
+
+message RecordInstallEventRequest {
+  // event_id is the client-minted WAL-dedup UUID (spec Decision 4).
+  string event_id = 1;
+  string mac = 2;
+  string status = 3;
+  string detail_json = 4;
+  string started_at = 5;
+  string finished_at = 6;
+}
+
+message ReinstallMachineRequest {
+  string mac = 1;
+  bool confirm_cooldown_override = 2;
+}
+
+message ReinstallMachineResponse {
+  string saga_id = 1;
+  bool ok = 2;
+  string detail = 3;
+}
+
+message UpsertDiscoveredMacRequest {
+  string mac = 1;
+  string arch_hint = 2;
+  string vendor_class = 3;
+  string seen_at = 4;
+}
+
+// Machine mirrors the CRDB `machines` table columns (spec Data model) plus
+// the Decision-13 reconciliation fields.
+message Machine {
+  string mac = 1;
+  string hostname = 2;
+  string ip = 3;
+  string type = 4;
+  string status = 5;
+  string boot_target = 6;
+  string tpm_ek = 7;
+  string registered_at = 8;
+  string approved_at = 9;
+  string last_seen = 10;
+  string last_ip = 11;
+  string installed_at = 12;
+  string last_install_status = 13;
+  string updated_at = 14;
+  // Decision-13 reconciliation fields.
+  string web_layer_target = 15;
+  string pxe_layer_target = 16;
+  bool consistent = 17;
+}
+
+message Ack {
+  bool ok = 1;
+  string detail = 2;
+}

--- a/proto/uaa/enroll/v1/enroll.proto
+++ b/proto/uaa/enroll/v1/enroll.proto
@@ -1,0 +1,38 @@
+// file: proto/uaa/enroll/v1/enroll.proto
+// version: 1.0.0
+// guid: 155a93c5-ef54-4b36-af8a-aa6068a36d74
+// last-edited: 2026-07-10
+
+syntax = "proto3";
+
+package uaa.enroll.v1;
+
+// EnrollService handles CSR submission and credential status/retrieval for
+// machine identity enrollment (spec C6).
+service EnrollService {
+  rpc SubmitCsr(SubmitCsrRequest) returns (SubmitCsrResponse);
+  rpc GetCredential(GetCredentialRequest) returns (GetCredentialResponse);
+}
+
+message SubmitCsrRequest {
+  string csr_pem = 1;
+  string claimed_hostname = 2;
+  string claimed_mac = 3;
+}
+
+message SubmitCsrResponse {
+  string spki_fingerprint = 1;
+  string state = 2;
+}
+
+message GetCredentialRequest {
+  string spki_fingerprint = 1;
+}
+
+message GetCredentialResponse {
+  // state is one of: pending|approved|issued|rejected|revoked|superseded
+  // (spec C6).
+  string state = 1;
+  string cert_pem = 2;
+  string ca_pem = 3;
+}

--- a/proto/uaa/pxe/v1/pxe.proto
+++ b/proto/uaa/pxe/v1/pxe.proto
@@ -1,0 +1,68 @@
+// file: proto/uaa/pxe/v1/pxe.proto
+// version: 1.0.0
+// guid: 4de6b19f-29b8-4497-976d-33a22ebdced6
+// last-edited: 2026-07-10
+
+syntax = "proto3";
+
+package uaa.pxe.v1;
+
+// PxeService is the PXE-layer API: dnsmasq/tftpd setup and boot-target
+// application, health reporting, discovered-MAC streaming, and DNS record
+// management.
+service PxeService {
+  rpc SetupPxe(SetupPxeRequest) returns (Ack);
+  rpc SetBootTarget(SetBootTargetRequest) returns (Ack);
+  rpc Health(HealthRequest) returns (HealthResponse);
+  rpc StreamDiscoveredMacs(StreamDiscoveredMacsRequest) returns (stream DiscoveredMac);
+  rpc SetDnsRecord(SetDnsRecordRequest) returns (Ack);
+}
+
+message Ack {
+  bool ok = 1;
+  string detail = 2;
+}
+
+message SetupPxeRequest {
+  string mac = 1;
+  string hostname = 2;
+  string boot_target = 3;
+}
+
+message SetBootTargetRequest {
+  string mac = 1;
+  string boot_target = 2;
+}
+
+message HealthRequest {}
+
+message HealthResponse {
+  bool dnsmasq_active = 1;
+  bool tftpd_active = 2;
+  bool tftp_probe_ok = 3;
+  repeated BootTargetState targets = 4;
+}
+
+message BootTargetState {
+  string mac = 1;
+  string expected = 2;
+  string applied = 3;
+  bool consistent = 4;
+}
+
+message StreamDiscoveredMacsRequest {}
+
+message DiscoveredMac {
+  string mac = 1;
+  string first_seen = 2;
+  string last_seen = 3;
+  string arch_hint = 4;
+  string vendor_class = 5;
+  bool dismissed = 6;
+}
+
+message SetDnsRecordRequest {
+  string hostname = 1;
+  string ip = 2;
+  bool remove = 3;
+}

--- a/proto/uaa/update/v1/update.proto
+++ b/proto/uaa/update/v1/update.proto
@@ -1,0 +1,24 @@
+// file: proto/uaa/update/v1/update.proto
+// version: 1.0.0
+// guid: 8a8337c4-f65f-4720-a740-252dae4454ec
+// last-edited: 2026-07-10
+
+syntax = "proto3";
+
+package uaa.update.v1;
+
+// Messages only — served as JSON by uaa-web, not a gRPC service (spec C7).
+
+message Manifest {
+  repeated BinaryEntry binaries = 1;
+  string min_version = 2;
+}
+
+message BinaryEntry {
+  string name = 1;
+  string version = 2;
+  string target = 3;
+  string sha256 = 4;
+  string sig = 5;
+  string url = 6;
+}

--- a/proto/uaa/web/v1/web.proto
+++ b/proto/uaa/web/v1/web.proto
@@ -1,0 +1,101 @@
+// file: proto/uaa/web/v1/web.proto
+// version: 1.0.0
+// guid: f4c7cc83-6e3e-4566-9159-0b8c94454a07
+// last-edited: 2026-07-10
+
+syntax = "proto3";
+
+package uaa.web.v1;
+
+// WebService is the web-layer API: seed/iPXE placement, boot-target
+// flips, host removal, ISO catalog + build jobs, and agent binary
+// publication.
+service WebService {
+  rpc PlaceSeed(PlaceSeedRequest) returns (Ack);
+  rpc PlaceIpxe(PlaceIpxeRequest) returns (Ack);
+  rpc FlipBootTarget(FlipBootTargetRequest) returns (FlipBootTargetResponse);
+  rpc RemoveHost(RemoveHostRequest) returns (Ack);
+  rpc ListIsos(ListIsosRequest) returns (ListIsosResponse);
+  rpc BuildIso(BuildIsoRequest) returns (BuildIsoResponse);
+  rpc GetBuildJob(GetBuildJobRequest) returns (BuildJob);
+  rpc PublishAgentBinary(PublishAgentBinaryRequest) returns (Ack);
+}
+
+message Ack {
+  bool ok = 1;
+  string detail = 2;
+}
+
+message PlaceSeedRequest {
+  string mac = 1;
+  // Non-secret fields + REPLACE_AT_PLACE_TIME placeholders ONLY
+  // (gate enforced by WB-02).
+  string user_data = 2;
+  string meta_data = 3;
+  string vendor_data = 4;
+  string network_config = 5;
+  string uaa_config = 6;
+}
+
+message PlaceIpxeRequest {
+  string hostname = 1;
+  string content = 2;
+}
+
+message FlipBootTargetRequest {
+  string hostname = 1;
+  string target = 2;
+}
+
+message FlipBootTargetResponse {
+  // Missing iPXE file is ok:false, not an error.
+  bool ok = 1;
+  string detail = 2;
+}
+
+message RemoveHostRequest {
+  string hostname = 1;
+  string mac = 2;
+}
+
+message ListIsosRequest {}
+
+message ListIsosResponse {
+  repeated IsoInfo isos = 1;
+}
+
+message IsoInfo {
+  string name = 1;
+  uint64 size_bytes = 2;
+  string sha256 = 3;
+}
+
+message BuildIsoRequest {
+  string base_iso = 1;
+  string profile = 2;
+}
+
+message BuildIsoResponse {
+  // Detached job (spec C4).
+  string job_id = 1;
+}
+
+message GetBuildJobRequest {
+  string job_id = 1;
+}
+
+message BuildJob {
+  string job_id = 1;
+  string state = 2;
+  string detail = 3;
+  string artifact_path = 4;
+}
+
+message PublishAgentBinaryRequest {
+  string name = 1;
+  string version = 2;
+  string target = 3;
+  bytes artifact = 4;
+  // signature verified before placement.
+  bytes signature = 5;
+}


### PR DESCRIPTION
Wave 2. Adds the `uaa-proto` crate (protox pure-Rust compile, no protoc), the 5 versioned proto packages (control/enroll/web/pxe/update v1 per spec), and the full `[workspace.dependencies]` table. +2 smoke tests. Rebased onto main; gate green (50+275+2=327, clippy clean). Musl-check needs homebrew musl-cross env locally (pre-existing on this repo — ring/ssh2 build scripts); CI has musl-tools. Brief: docs/agent-tasks/core-proto/TASK-02-proto-crate-protox.md

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>