### PR TITLE
feat(control): wave-4 batch (CT-02/03/04/06 + IP-02) + router wiring

### DIFF
--- a/crates/uaa-control/Cargo.toml
+++ b/crates/uaa-control/Cargo.toml
@@ -1,5 +1,5 @@
 # file: crates/uaa-control/Cargo.toml
-# version: 1.0.0
+# version: 1.1.0
 # guid: 1e1a4386-a459-4a97-8baf-c942283b3107
 # last-edited: 2026-07-10
 
@@ -45,6 +45,15 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
+# Wave-4 fillers: OAuth/RBAC (CT-03), audit chain (CT-04), parity endpoints (IP-01/02)
+reqwest = { workspace = true }
+ring = { workspace = true }
+base64 = { workspace = true }
+ed25519-dalek = { workspace = true }
+rand = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+tower = { version = "0.5", features = ["util"] }
 # Sibling crates
 uaa-proto = { path = "../uaa-proto" }
 uaa-core = { path = "../uaa-core" }

--- a/crates/uaa-control/src/audit.rs
+++ b/crates/uaa-control/src/audit.rs
@@ -1,8 +1,886 @@
 // file: crates/uaa-control/src/audit.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f807be1-d330-43bd-b5a5-c38d17dfcb66
 // last-edited: 2026-07-10
 
-//! Hash-chained audit log (Decision 21) + daily ed25519 checkpoints.
+//! Hash-chained audit log (spec Decision 21) + daily ed25519 checkpoints.
 //!
-//! STUB — Filled exclusively by control TASK-04 (CT-04). Backs the `audit` subcommand.
+//! Every mutating action in the constellation is recorded as an
+//! [`AuditEventRow`] that is cryptographically linked to its predecessor:
+//! `hash = SHA-256(prev_hash || canonical_bytes(event))`, where
+//! `canonical_bytes` is the JSON serialization of
+//! `(at, actor, role, action, target, outcome, detail)` with sorted keys
+//! (built via a [`std::collections::BTreeMap`] so ordering never depends on
+//! `serde_json`'s `preserve_order` feature). The very first event's
+//! `prev_hash` is exactly [`GENESIS_PREV_HASH`] — 32 zero bytes.
+//!
+//! # Serialization (Decision 21, repeated here and in [`AuditStore`])
+//!
+//! The append happens in the SAME database transaction as the mutation it
+//! records, and `prev_hash` is read from the chain tip under
+//! `SELECT hash FROM audit_events ORDER BY seq DESC LIMIT 1 FOR UPDATE`. Two
+//! concurrent mutations therefore serialize on that row lock — the tip read
+//! and the subsequent insert are one critical section, so the chain can
+//! NEVER fork. [`MemAuditStore`] emulates this with a `std::sync::Mutex` held
+//! across read-tip -> (caller mutation) -> insert; [`PgAuditStore`] pins the
+//! shape in SQL text (`SQL_SELECT_TIP` literally contains `FOR UPDATE`,
+//! asserted by `test_pg_tip_sql_has_for_update`) so it is unavoidable for any
+//! real implementation.
+//!
+//! # Threat model (STATED, not extended — Decision 21b)
+//!
+//! The chain plus the on-server ed25519 audit key defends against a **rogue
+//! operator without server root**: they cannot rewrite history through the
+//! normal API surface without [`verify_chain`] detecting the break. A
+//! **server-root adversary defeats it** — they can rewrite the CockroachDB
+//! rows and the on-disk signing key together, and nothing in this module
+//! claims otherwise. Out-of-band checkpoint witnessing (publishing the daily
+//! signed tip somewhere the root adversary cannot also rewrite) is recorded
+//! P2 hardening and is explicitly NOT built here.
+//!
+//! # Cargo tests need no live CockroachDB
+//!
+//! Everything DB-shaped sits behind the [`AuditStore`] trait. Unit tests use
+//! [`MemAuditStore`]; [`PgAuditStore`] is the runtime implementation and is
+//! never constructed or exercised by `cargo test` (its SQL is asserted as
+//! text only).
+
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+use std::sync::Mutex;
+
+use ed25519_dalek::{Signature, Signer, SigningKey};
+use rand::rngs::OsRng;
+use sha2::{Digest, Sha256};
+
+use crate::db::{AuditCheckpointRow, AuditEventRow};
+
+/// Genesis `prev_hash`: exactly 32 zero bytes. The first event in the chain
+/// (and only the first) has this as its `prev_hash`.
+pub const GENESIS_PREV_HASH: [u8; 32] = [0u8; 32];
+
+/// Owner-only file mode for the on-server audit signing key.
+const OWNER_ONLY: u32 = 0o600;
+
+/// Filename of the on-server ed25519 audit signing key under `state_dir`.
+const AUDIT_KEY_FILENAME: &str = "audit-signing-key";
+
+// ── Canonical hashing ───────────────────────────────────────────────────────
+
+/// The not-yet-persisted shape of an audit event: exactly the fields that
+/// feed the hash (`at, actor, role, action, target, outcome, detail`). `at`
+/// is minted by the caller (never the database's `DEFAULT now()`) because it
+/// must be fixed and known BEFORE the hash is computed.
+#[derive(Debug, Clone)]
+pub struct NewAuditEvent {
+    pub at: String,
+    pub actor: String,
+    pub role: String,
+    pub action: String,
+    pub target: Option<String>,
+    pub outcome: String,
+    pub detail: Option<serde_json::Value>,
+}
+
+impl From<&AuditEventRow> for NewAuditEvent {
+    /// Reconstructs the hashed fields from a persisted row — used by
+    /// [`verify_chain`] to recompute (never trust) each stored `hash`.
+    fn from(row: &AuditEventRow) -> Self {
+        Self {
+            at: row.at.clone().unwrap_or_default(),
+            actor: row.actor.clone(),
+            role: row.role.clone(),
+            action: row.action.clone(),
+            target: row.target.clone(),
+            outcome: row.outcome.clone(),
+            detail: row.detail.clone(),
+        }
+    }
+}
+
+/// Deterministic JSON bytes for `event`: a `BTreeMap` (sorted keys) over
+/// `(at, actor, role, action, target, outcome, detail)`. Missing `target`/
+/// `detail` serialize as JSON `null`, never an absent key, so the shape is
+/// stable across events regardless of which optional fields are set.
+fn canonical_bytes(event: &NewAuditEvent) -> Vec<u8> {
+    let mut map: BTreeMap<&'static str, serde_json::Value> = BTreeMap::new();
+    map.insert("at", serde_json::Value::String(event.at.clone()));
+    map.insert("actor", serde_json::Value::String(event.actor.clone()));
+    map.insert("role", serde_json::Value::String(event.role.clone()));
+    map.insert("action", serde_json::Value::String(event.action.clone()));
+    map.insert(
+        "target",
+        event
+            .target
+            .clone()
+            .map(serde_json::Value::String)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    map.insert("outcome", serde_json::Value::String(event.outcome.clone()));
+    map.insert(
+        "detail",
+        event.detail.clone().unwrap_or(serde_json::Value::Null),
+    );
+    serde_json::to_vec(&map).expect("BTreeMap<&str, Value> always serializes")
+}
+
+/// `hash = SHA-256(prev_hash || canonical_bytes(event))` (spec Decision 21).
+/// Re-computable from a persisted row via `NewAuditEvent::from`, which is
+/// exactly what [`verify_chain`] does to detect tampering.
+pub fn event_hash(prev_hash: &[u8; 32], event: &NewAuditEvent) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(prev_hash);
+    hasher.update(canonical_bytes(event));
+    hasher.finalize().into()
+}
+
+// ── Store trait (behind which live/mock persistence hides) ─────────────────
+
+/// A caller-supplied unit of work that must commit atomically WITH the audit
+/// append (the "mutation this event records" — spec Decision 21). It runs
+/// inside the same critical section as the tip lock, after the tip is read
+/// and before the audit row is inserted. `record`/`backfill` pass a no-op
+/// mutation (`Ok(())`) since they have no accompanying registry change of
+/// their own; sibling tasks recording an audited registry mutation pass
+/// their real mutation here so it is impossible to append the audit event
+/// without also committing (or, on error, rolling back) the paired change.
+pub type MutationFn<'a> = Box<dyn FnOnce() -> anyhow::Result<()> + Send + 'a>;
+
+/// Persistence seam for the audit chain. Every method here is the one place
+/// concurrency correctness (Decision 21: never fork) is enforced —
+/// [`MemAuditStore`] with a held `Mutex`, [`PgAuditStore`] with `SELECT ...
+/// FOR UPDATE` inside a CockroachDB transaction.
+#[async_trait::async_trait]
+pub trait AuditStore: Send + Sync {
+    /// Lock+read the tip, run `mutation`, compute the chained hash, insert —
+    /// all as ONE critical section / database transaction. Concurrent
+    /// callers serialize on the tip lock; the chain can never fork.
+    async fn append_in_txn(
+        &self,
+        mutation: MutationFn<'_>,
+        event: NewAuditEvent,
+    ) -> anyhow::Result<AuditEventRow>;
+
+    /// Events with `seq >= from_seq`, ordered ascending by `seq`.
+    async fn list_events(&self, from_seq: i64) -> anyhow::Result<Vec<AuditEventRow>>;
+
+    /// The current chain tip as `(seq, hash)`, or `None` for an empty chain.
+    async fn tip(&self) -> anyhow::Result<Option<(i64, Vec<u8>)>>;
+
+    /// Persist one daily checkpoint row.
+    async fn insert_checkpoint(&self, checkpoint: AuditCheckpointRow) -> anyhow::Result<()>;
+}
+
+// ── MemAuditStore: the test double (and export for sibling tasks) ──────────
+
+#[derive(Debug, Default)]
+struct MemInner {
+    events: Vec<AuditEventRow>,
+    checkpoints: Vec<AuditCheckpointRow>,
+}
+
+/// In-memory [`AuditStore`] for `cargo test` (zero network, zero CockroachDB)
+/// and for sibling control tasks that need a chain in their own unit tests.
+/// A single `std::sync::Mutex` is held across tip-read -> mutation -> insert,
+/// exactly emulating CockroachDB's `SELECT ... FOR UPDATE` tip lock: no
+/// `.await` ever happens while the guard is held, so this is safe under the
+/// multi-threaded tokio runtime and proves the serialization property
+/// (`test_concurrent_appends_never_fork`) without a real database.
+#[derive(Debug, Default)]
+pub struct MemAuditStore {
+    inner: Mutex<MemInner>,
+}
+
+impl MemAuditStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl AuditStore for MemAuditStore {
+    async fn append_in_txn(
+        &self,
+        mutation: MutationFn<'_>,
+        event: NewAuditEvent,
+    ) -> anyhow::Result<AuditEventRow> {
+        let mut guard = self.inner.lock().expect("MemAuditStore mutex poisoned");
+
+        let prev_hash: [u8; 32] = match guard.events.last() {
+            Some(tip) => to_arr32(&tip.hash).unwrap_or(GENESIS_PREV_HASH),
+            None => GENESIS_PREV_HASH,
+        };
+
+        // The paired mutation runs INSIDE the lock: it commits (or fails,
+        // aborting the whole append) atomically with the audit row.
+        mutation()?;
+
+        let hash = event_hash(&prev_hash, &event);
+        let seq = guard.events.len() as i64 + 1;
+        let row = AuditEventRow {
+            seq,
+            at: Some(event.at),
+            actor: event.actor,
+            role: event.role,
+            action: event.action,
+            target: event.target,
+            outcome: event.outcome,
+            detail: event.detail,
+            prev_hash: prev_hash.to_vec(),
+            hash: hash.to_vec(),
+        };
+        guard.events.push(row.clone());
+        Ok(row)
+    }
+
+    async fn list_events(&self, from_seq: i64) -> anyhow::Result<Vec<AuditEventRow>> {
+        let guard = self.inner.lock().expect("MemAuditStore mutex poisoned");
+        Ok(guard
+            .events
+            .iter()
+            .filter(|e| e.seq >= from_seq)
+            .cloned()
+            .collect())
+    }
+
+    async fn tip(&self) -> anyhow::Result<Option<(i64, Vec<u8>)>> {
+        let guard = self.inner.lock().expect("MemAuditStore mutex poisoned");
+        Ok(guard.events.last().map(|e| (e.seq, e.hash.clone())))
+    }
+
+    async fn insert_checkpoint(&self, checkpoint: AuditCheckpointRow) -> anyhow::Result<()> {
+        let mut guard = self.inner.lock().expect("MemAuditStore mutex poisoned");
+        guard.checkpoints.push(checkpoint);
+        Ok(())
+    }
+}
+
+fn to_arr32(bytes: &[u8]) -> Option<[u8; 32]> {
+    bytes.try_into().ok()
+}
+
+// ── PgAuditStore: the runtime implementation (never live-tested here) ──────
+
+/// Tip-lock SQL (Decision 21). This literal `FOR UPDATE` is what makes
+/// concurrent appends serialize on the tip row instead of forking the chain;
+/// `test_pg_tip_sql_has_for_update` asserts it textually. Never executed by
+/// `cargo test` — [`PgAuditStore`] requires a live CockroachDB connection.
+const SQL_SELECT_TIP: &str = "SELECT seq, hash FROM audit_events ORDER BY seq DESC LIMIT 1 FOR UPDATE";
+const SQL_SELECT_ONE_TIP: &str = "SELECT seq, hash FROM audit_events ORDER BY seq DESC LIMIT 1";
+const SQL_INSERT_EVENT: &str = "INSERT INTO audit_events \
+    (at, actor, role, action, target, outcome, detail, prev_hash, hash) \
+    VALUES ($1::timestamptz, $2, $3, $4, $5, $6, $7::jsonb, $8, $9) \
+    RETURNING seq, at::text, actor, role, action, target, outcome, detail::text, prev_hash, hash";
+const SQL_SELECT_EVENTS_FROM: &str = "SELECT seq, at::text, actor, role, action, target, outcome, \
+    detail::text, prev_hash, hash FROM audit_events WHERE seq >= $1 ORDER BY seq ASC";
+const SQL_INSERT_CHECKPOINT: &str =
+    "INSERT INTO audit_checkpoints (day, tip_seq, tip_hash, signature) VALUES ($1::date, $2, $3, $4)";
+
+/// Real [`AuditStore`]: appends inside a CockroachDB transaction with the
+/// tip locked under `FOR UPDATE` (`SQL_SELECT_TIP`). `detail` is round-
+/// tripped as a text-cast JSONB column (`::jsonb` / `::text`) rather than
+/// via `tokio-postgres`'s typed JSON conversion, so this compiles against
+/// the workspace's default `tokio-postgres` feature set (no
+/// `with-serde_json-1` needed). Constructed only at runtime — unit tests
+/// never build one.
+pub struct PgAuditStore {
+    /// libpq-style connection string; secrets injected at runtime.
+    pub conninfo: String,
+}
+
+impl PgAuditStore {
+    async fn connect(&self) -> anyhow::Result<(tokio_postgres::Client, tokio::task::JoinHandle<()>)> {
+        let (client, connection) =
+            tokio_postgres::connect(&self.conninfo, tokio_postgres::NoTls).await?;
+        let handle = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        Ok((client, handle))
+    }
+}
+
+fn row_from_pg(row: &tokio_postgres::Row) -> anyhow::Result<AuditEventRow> {
+    let detail_text: Option<String> = row.get(7);
+    let detail = detail_text.map(|t| serde_json::from_str(&t)).transpose()?;
+    Ok(AuditEventRow {
+        seq: row.get(0),
+        at: row.get(1),
+        actor: row.get(2),
+        role: row.get(3),
+        action: row.get(4),
+        target: row.get(5),
+        outcome: row.get(6),
+        detail,
+        prev_hash: row.get(8),
+        hash: row.get(9),
+    })
+}
+
+#[async_trait::async_trait]
+impl AuditStore for PgAuditStore {
+    async fn append_in_txn(
+        &self,
+        mutation: MutationFn<'_>,
+        event: NewAuditEvent,
+    ) -> anyhow::Result<AuditEventRow> {
+        let (mut client, handle) = self.connect().await?;
+        let txn = client.transaction().await?;
+
+        // Tip lock: held for the rest of this transaction (commit/rollback
+        // below), so a concurrent appender blocks here until we finish.
+        let tip_row = txn.query_opt(SQL_SELECT_TIP, &[]).await?;
+        let prev_hash: [u8; 32] = match tip_row {
+            Some(row) => {
+                let h: Vec<u8> = row.get(1);
+                to_arr32(&h).ok_or_else(|| anyhow::anyhow!("corrupt tip hash length"))?
+            }
+            None => GENESIS_PREV_HASH,
+        };
+
+        mutation()?;
+
+        let hash = event_hash(&prev_hash, &event);
+        let detail_text = event.detail.as_ref().map(|v| v.to_string());
+        let row = txn
+            .query_one(
+                SQL_INSERT_EVENT,
+                &[
+                    &event.at,
+                    &event.actor,
+                    &event.role,
+                    &event.action,
+                    &event.target,
+                    &event.outcome,
+                    &detail_text,
+                    &prev_hash.to_vec(),
+                    &hash.to_vec(),
+                ],
+            )
+            .await?;
+        txn.commit().await?;
+        handle.abort();
+        row_from_pg(&row)
+    }
+
+    async fn list_events(&self, from_seq: i64) -> anyhow::Result<Vec<AuditEventRow>> {
+        let (client, handle) = self.connect().await?;
+        let rows = client.query(SQL_SELECT_EVENTS_FROM, &[&from_seq]).await?;
+        handle.abort();
+        rows.iter().map(row_from_pg).collect()
+    }
+
+    async fn tip(&self) -> anyhow::Result<Option<(i64, Vec<u8>)>> {
+        let (client, handle) = self.connect().await?;
+        let row = client.query_opt(SQL_SELECT_ONE_TIP, &[]).await?;
+        handle.abort();
+        Ok(row.map(|r| (r.get(0), r.get(1))))
+    }
+
+    async fn insert_checkpoint(&self, checkpoint: AuditCheckpointRow) -> anyhow::Result<()> {
+        let (client, handle) = self.connect().await?;
+        client
+            .execute(
+                SQL_INSERT_CHECKPOINT,
+                &[
+                    &checkpoint.day,
+                    &checkpoint.tip_seq,
+                    &checkpoint.tip_hash,
+                    &checkpoint.signature,
+                ],
+            )
+            .await?;
+        handle.abort();
+        Ok(())
+    }
+}
+
+// ── record / backfill ───────────────────────────────────────────────────────
+
+/// Mints `at` (RFC3339, UTC) and appends a chained audit event with no
+/// paired registry mutation of its own. This is the entrypoint used by
+/// [`backfill`], the `audit checkpoint`/`audit verify` CLI paths, and most
+/// tests. Sibling tasks that DO have an accompanying mutation should call
+/// [`AuditStore::append_in_txn`] directly with their own [`MutationFn`] so
+/// the mutation and the audit row commit atomically together.
+#[allow(clippy::too_many_arguments)]
+pub async fn record(
+    store: &dyn AuditStore,
+    actor: impl Into<String>,
+    role: impl Into<String>,
+    action: impl Into<String>,
+    target: Option<String>,
+    outcome: impl Into<String>,
+    detail: Option<serde_json::Value>,
+) -> anyhow::Result<AuditEventRow> {
+    let event = NewAuditEvent {
+        at: chrono::Utc::now().to_rfc3339(),
+        actor: actor.into(),
+        role: role.into(),
+        action: action.into(),
+        target,
+        outcome: outcome.into(),
+        detail,
+    };
+    store.append_in_txn(Box::new(|| Ok(())), event).await
+}
+
+/// The Decision-8 emergency-hatch companion: records an out-of-band
+/// `cockroach sql` mutation AFTER the fact, through the SAME serialized
+/// append path as any other event (`role = "system"`, `action` prefixed
+/// `backfill:`). No side door — a backfilled event is chained exactly like
+/// any other.
+pub async fn backfill(
+    store: &dyn AuditStore,
+    actor: impl Into<String>,
+    action: impl Into<String>,
+    target: Option<String>,
+    outcome: impl Into<String>,
+    detail: Option<serde_json::Value>,
+) -> anyhow::Result<AuditEventRow> {
+    let action = format!("backfill:{}", action.into());
+    record(store, actor, "system", action, target, outcome, detail).await
+}
+
+/// CLI-ready parameters for `uaa-control audit backfill`.
+#[derive(Debug, Clone)]
+pub struct BackfillArgs {
+    pub actor: String,
+    pub action: String,
+    pub target: Option<String>,
+    pub outcome: String,
+    pub detail: Option<serde_json::Value>,
+}
+
+/// Runs [`backfill`] from parsed CLI args — the body of the `audit backfill`
+/// subcommand, exposed here so `main.rs`'s clap wiring is a one-line call.
+pub async fn run_backfill(store: &dyn AuditStore, args: BackfillArgs) -> anyhow::Result<AuditEventRow> {
+    backfill(
+        store,
+        args.actor,
+        args.action,
+        args.target,
+        args.outcome,
+        args.detail,
+    )
+    .await
+}
+
+// ── verify_chain ─────────────────────────────────────────────────────────
+
+/// Which check first failed at `seq` when a chain does not verify.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainDefectKind {
+    /// The first event's `prev_hash` is not [`GENESIS_PREV_HASH`].
+    BadGenesis,
+    /// A non-first event's `prev_hash` does not equal its predecessor's `hash`.
+    BadPrevHash,
+    /// A stored `hash` does not match the recomputed `event_hash`.
+    BadHash,
+}
+
+/// A chain-integrity failure, naming the first bad `seq`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("audit chain defect at seq {seq}: {kind:?}")]
+pub struct ChainDefect {
+    pub seq: i64,
+    pub kind: ChainDefectKind,
+}
+
+/// Walks `events` in the given order, recomputing every hash and checking
+/// genesis + linkage, returning the FIRST defect found (never trusts a
+/// stored `hash`/`prev_hash` without recomputing it). Callers pass events in
+/// `seq`-ascending order (as returned by [`AuditStore::list_events`]); a
+/// reordered or tampered slice is detected here.
+pub fn verify_chain(events: &[AuditEventRow]) -> Result<(), ChainDefect> {
+    let mut prev_expected = GENESIS_PREV_HASH;
+    for (i, row) in events.iter().enumerate() {
+        let row_prev = to_arr32(&row.prev_hash).unwrap_or([0xffu8; 32]);
+
+        if i == 0 {
+            if row_prev != GENESIS_PREV_HASH {
+                return Err(ChainDefect {
+                    seq: row.seq,
+                    kind: ChainDefectKind::BadGenesis,
+                });
+            }
+        } else if row_prev != prev_expected {
+            return Err(ChainDefect {
+                seq: row.seq,
+                kind: ChainDefectKind::BadPrevHash,
+            });
+        }
+
+        let recomputed = event_hash(&row_prev, &NewAuditEvent::from(row));
+        let row_hash = to_arr32(&row.hash).unwrap_or([0xfeu8; 32]);
+        if recomputed != row_hash {
+            return Err(ChainDefect {
+                seq: row.seq,
+                kind: ChainDefectKind::BadHash,
+            });
+        }
+        prev_expected = row_hash;
+    }
+    Ok(())
+}
+
+/// Runs [`verify_chain`] over the full stored chain and prints the outcome —
+/// the body of the `audit verify` subcommand.
+pub async fn run_verify(store: &dyn AuditStore) -> anyhow::Result<()> {
+    let events = store.list_events(0).await?;
+    match verify_chain(&events) {
+        Ok(()) => {
+            println!("audit chain OK: {} event(s) verified", events.len());
+            Ok(())
+        }
+        Err(defect) => {
+            println!("audit chain BROKEN: {defect}");
+            Err(defect.into())
+        }
+    }
+}
+
+// ── Daily checkpoint ─────────────────────────────────────────────────────
+
+/// Typed refusal reasons for [`daily_checkpoint`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum CheckpointError {
+    /// The chain has no events yet; refuse rather than sign an empty tip.
+    #[error("audit chain is empty; refusing to sign an empty checkpoint")]
+    EmptyChain,
+}
+
+/// The exact bytes a daily checkpoint signs: `day || tip_seq (8-byte BE) ||
+/// tip_hash`. Exposed so out-of-band witnessing tooling (P2 hardening,
+/// Decision 21b — not built here) can independently verify a checkpoint
+/// signature without re-deriving this layout.
+pub fn checkpoint_signing_bytes(day: &str, tip_seq: i64, tip_hash: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(day.len() + 8 + tip_hash.len());
+    buf.extend_from_slice(day.as_bytes());
+    buf.extend_from_slice(&tip_seq.to_be_bytes());
+    buf.extend_from_slice(tip_hash);
+    buf
+}
+
+/// Signs `day || tip_seq || tip_hash` with the on-server ed25519 audit key
+/// and persists the checkpoint row. An empty chain (no events yet) is
+/// refused with [`CheckpointError::EmptyChain`] — never a signed empty tip.
+pub async fn daily_checkpoint(
+    store: &dyn AuditStore,
+    signing_key: &SigningKey,
+    day: &str,
+) -> anyhow::Result<AuditCheckpointRow> {
+    let (tip_seq, tip_hash) = store.tip().await?.ok_or(CheckpointError::EmptyChain)?;
+    let signing_bytes = checkpoint_signing_bytes(day, tip_seq, &tip_hash);
+    let signature: Signature = signing_key.sign(&signing_bytes);
+
+    let checkpoint = AuditCheckpointRow {
+        day: day.to_string(),
+        tip_seq,
+        tip_hash,
+        signature: signature.to_bytes().to_vec(),
+    };
+    store.insert_checkpoint(checkpoint.clone()).await?;
+    Ok(checkpoint)
+}
+
+/// Runs [`daily_checkpoint`] and prints the outcome — the body of the
+/// `audit checkpoint` subcommand.
+pub async fn run_checkpoint(
+    store: &dyn AuditStore,
+    signing_key: &SigningKey,
+    day: &str,
+) -> anyhow::Result<AuditCheckpointRow> {
+    let checkpoint = daily_checkpoint(store, signing_key, day).await?;
+    println!(
+        "checkpoint signed for {day}: tip_seq={} tip_hash={}",
+        checkpoint.tip_seq,
+        hex_encode(&checkpoint.tip_hash)
+    );
+    Ok(checkpoint)
+}
+
+/// Today's UTC calendar date as `YYYY-MM-DD`, for `audit checkpoint`'s "sign
+/// today" default.
+pub fn today_utc_date() -> String {
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+// ── On-server audit signing key ─────────────────────────────────────────
+
+/// Loads the on-server ed25519 audit key from `<state_dir>/audit-signing-key`,
+/// generating and persisting (0600) a fresh one on first start. Tests pass a
+/// tempdir; production passes the daemon's real state directory.
+pub fn load_or_create_audit_key(state_dir: &Path) -> anyhow::Result<SigningKey> {
+    let key_path = state_dir.join(AUDIT_KEY_FILENAME);
+
+    if let Ok(bytes) = fs::read(&key_path) {
+        let arr = to_arr32(&bytes).ok_or_else(|| {
+            anyhow::anyhow!(
+                "corrupt audit signing key at {}: expected 32 bytes, found {}",
+                key_path.display(),
+                bytes.len()
+            )
+        })?;
+        return Ok(SigningKey::from_bytes(&arr));
+    }
+
+    fs::create_dir_all(state_dir)?;
+    let key = SigningKey::generate(&mut OsRng);
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(OWNER_ONLY)
+        .open(&key_path)?;
+    f.write_all(&key.to_bytes())?;
+    f.flush()?;
+    fs::set_permissions(&key_path, fs::Permissions::from_mode(OWNER_ONLY))?;
+    Ok(key)
+}
+
+// ── Unit tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Verifier;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_genesis_prev_hash_is_zero() {
+        let store = MemAuditStore::new();
+        let row = record(&store, "alice", "operator", "test.action", None, "success", None)
+            .await
+            .unwrap();
+        assert_eq!(row.seq, 1);
+        assert_eq!(row.prev_hash, GENESIS_PREV_HASH.to_vec());
+    }
+
+    #[tokio::test]
+    async fn test_append_links_prev_hash() {
+        let store = MemAuditStore::new();
+        let e1 = record(&store, "a", "operator", "act1", None, "ok", None).await.unwrap();
+        let e2 = record(&store, "a", "operator", "act2", None, "ok", None).await.unwrap();
+        let e3 = record(&store, "a", "operator", "act3", None, "ok", None).await.unwrap();
+
+        assert_eq!(e1.prev_hash, GENESIS_PREV_HASH.to_vec());
+        assert_eq!(e2.prev_hash, e1.hash, "e2 must link to e1's hash");
+        assert_eq!(e3.prev_hash, e2.hash, "e3 must link to e2's hash");
+
+        let all = store.list_events(0).await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(verify_chain(&all).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_appends_never_fork() {
+        // THE Decision-21 test: 16 tasks race to append through the same
+        // store. If the tip lock ever let two appends read the same tip,
+        // this would produce duplicate seqs, duplicate prev_hash links, or
+        // a `verify_chain` failure. None of that may happen.
+        let store = Arc::new(MemAuditStore::new());
+        let mut handles = Vec::new();
+        for i in 0..16 {
+            let store = Arc::clone(&store);
+            handles.push(tokio::spawn(async move {
+                record(
+                    &*store,
+                    format!("actor-{i}"),
+                    "operator",
+                    "concurrent.append",
+                    None,
+                    "ok",
+                    None,
+                )
+                .await
+                .unwrap()
+            }));
+        }
+
+        let mut seqs: Vec<i64> = Vec::new();
+        for h in handles {
+            seqs.push(h.await.unwrap().seq);
+        }
+        seqs.sort_unstable();
+        assert_eq!(
+            seqs,
+            (1..=16).collect::<Vec<_>>(),
+            "seq must be exactly 1..=16 with no gaps or duplicates"
+        );
+
+        let all = store.list_events(0).await.unwrap();
+        assert_eq!(all.len(), 16);
+        assert!(
+            verify_chain(&all).is_ok(),
+            "16 concurrent appends must form ONE linear verified chain, never fork"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verify_detects_tamper() {
+        let store = MemAuditStore::new();
+        record(&store, "a", "operator", "act1", None, "ok", None).await.unwrap();
+        record(
+            &store,
+            "a",
+            "operator",
+            "act2",
+            None,
+            "ok",
+            Some(serde_json::json!({"x": 1})),
+        )
+        .await
+        .unwrap();
+        record(&store, "a", "operator", "act3", None, "ok", None).await.unwrap();
+
+        let mut events = store.list_events(0).await.unwrap();
+        // Tamper the middle event's detail WITHOUT recomputing its hash.
+        events[1].detail = Some(serde_json::json!({"x": 999}));
+
+        let err = verify_chain(&events).unwrap_err();
+        assert_eq!(err.seq, events[1].seq);
+        assert_eq!(err.kind, ChainDefectKind::BadHash);
+    }
+
+    #[tokio::test]
+    async fn test_verify_detects_reorder() {
+        let store = MemAuditStore::new();
+        for i in 0..4 {
+            record(&store, "a", "operator", format!("act{i}"), None, "ok", None)
+                .await
+                .unwrap();
+        }
+        let mut events = store.list_events(0).await.unwrap();
+        events.swap(1, 2);
+
+        let err = verify_chain(&events).unwrap_err();
+        assert_eq!(err.kind, ChainDefectKind::BadPrevHash);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_signs_tip() {
+        let store = MemAuditStore::new();
+        record(&store, "a", "operator", "act1", None, "ok", None).await.unwrap();
+        let last = record(&store, "a", "operator", "act2", None, "ok", None).await.unwrap();
+
+        let dir = tempdir().unwrap();
+        let signing_key = load_or_create_audit_key(dir.path()).unwrap();
+        let verifying_key = signing_key.verifying_key();
+
+        let checkpoint = daily_checkpoint(&store, &signing_key, "2026-07-10").await.unwrap();
+        assert_eq!(checkpoint.tip_seq, last.seq);
+        assert_eq!(checkpoint.tip_hash, last.hash);
+
+        let signing_bytes =
+            checkpoint_signing_bytes(&checkpoint.day, checkpoint.tip_seq, &checkpoint.tip_hash);
+        let sig_bytes: [u8; 64] = checkpoint.signature.as_slice().try_into().unwrap();
+        let sig = Signature::from_bytes(&sig_bytes);
+        assert!(verifying_key.verify(&signing_bytes, &sig).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_empty_chain_refused() {
+        let store = MemAuditStore::new();
+        let dir = tempdir().unwrap();
+        let signing_key = load_or_create_audit_key(dir.path()).unwrap();
+
+        let err = daily_checkpoint(&store, &signing_key, "2026-07-10").await.unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<CheckpointError>(),
+            Some(&CheckpointError::EmptyChain),
+            "must refuse with a typed error, never sign an empty tip"
+        );
+        assert!(store.tip().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_backfill_goes_through_chain() {
+        let store = MemAuditStore::new();
+        record(&store, "a", "operator", "normal.action", None, "ok", None)
+            .await
+            .unwrap();
+
+        let row = run_backfill(
+            &store,
+            BackfillArgs {
+                actor: "github-login".into(),
+                action: "manual-fix".into(),
+                target: Some("machine:aa:bb:cc:dd:ee:ff".into()),
+                outcome: "applied".into(),
+                detail: Some(serde_json::json!({"note": "ran cockroach sql by hand"})),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(row.role, "system");
+        assert!(
+            row.action.starts_with("backfill:"),
+            "backfill action must be prefixed"
+        );
+        assert_eq!(row.seq, 2, "backfill goes through the SAME serialized append (no side door)");
+
+        let all = store.list_events(0).await.unwrap();
+        assert!(verify_chain(&all).is_ok());
+    }
+
+    #[test]
+    fn test_pg_tip_sql_has_for_update() {
+        assert!(SQL_SELECT_TIP.contains("FOR UPDATE"));
+    }
+
+    #[tokio::test]
+    async fn test_record_happy_path_returns_row() {
+        // Anti-over-suppression: the tip lock must not deadlock or block the
+        // ordinary single-append path, and every field must round-trip.
+        let store = MemAuditStore::new();
+        let row = record(
+            &store,
+            "alice",
+            "operator",
+            "machine.approve",
+            Some("aa:bb:cc:dd:ee:ff".into()),
+            "success",
+            Some(serde_json::json!({"note": "ok"})),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(row.seq, 1);
+        assert_eq!(row.actor, "alice");
+        assert_eq!(row.role, "operator");
+        assert_eq!(row.action, "machine.approve");
+        assert_eq!(row.target.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
+        assert_eq!(row.outcome, "success");
+        assert_eq!(row.detail, Some(serde_json::json!({"note": "ok"})));
+        assert_eq!(row.prev_hash, GENESIS_PREV_HASH.to_vec());
+        assert!(verify_chain(std::slice::from_ref(&row)).is_ok());
+    }
+
+    #[test]
+    fn test_load_or_create_audit_key_persists_0600() {
+        let dir = tempdir().unwrap();
+        let key1 = load_or_create_audit_key(dir.path()).unwrap();
+        let key2 = load_or_create_audit_key(dir.path()).unwrap();
+        assert_eq!(
+            key1.to_bytes(),
+            key2.to_bytes(),
+            "second call must load the persisted key, not mint a new one"
+        );
+
+        let mode = fs::metadata(dir.path().join(AUDIT_KEY_FILENAME))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/crates/uaa-control/src/auth.rs
+++ b/crates/uaa-control/src/auth.rs
@@ -1,8 +1,1046 @@
 // file: crates/uaa-control/src/auth.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: af3dc9c0-def6-46ff-9892-90e54716fe21
 // last-edited: 2026-07-10
 
-//! RBAC + operator authentication (GitHub OIDC / role mapping).
+//! RBAC + operator authentication: GitHub OAuth web flow + org/team role mapping
+//! (spec Decision 8, component C3 "Operator plane").
 //!
-//! STUB — Filled exclusively by control TASK-03 (CT-03).
+//! Filled by control TASK-03 (CT-03). Scope, locked by Decision 8:
+//!
+//! * GitHub OAuth web flow ONLY — authorize redirect, code-for-token exchange, then a
+//!   `login` + org/team lookup. No local accounts, no alternate credential store, no
+//!   hardware-token second factor, no PIV/mTLS operator login.
+//! * RBAC is org-team based: `uaa-admins` team membership -> [`Role::Admin`],
+//!   `uaa-operators` team membership -> [`Role::Operator`], plain org membership ->
+//!   [`Role::Viewer`], not an org member -> 403 at login (no session minted).
+//! * Role cache TTL is 5 minutes ([`ROLE_CACHE_TTL`]); on any GitHub API failure the
+//!   effective role for that request degrades to [`Role::Viewer`] — mutations are
+//!   denied, reads stay available. A stale cached [`Role::Admin`] is NEVER served past
+//!   its TTL.
+//! * Session cookies are HMAC-SHA256 signed (`ring::hmac`), `Secure; HttpOnly;
+//!   SameSite=Lax`, 24h lifetime, keyed by a 32-byte key persisted 0600 under the
+//!   configured state dir.
+//! * Everything GitHub-shaped goes through the [`GithubApi`] trait so unit tests never
+//!   touch the network — see `mod tests` for the mock implementation. The real impl
+//!   ([`RealGithubApi`]) uses `reqwest` with the workspace's rustls-tls feature; no new
+//!   HTTP client crate.
+//!
+//! ## Emergency access during a GitHub outage
+//!
+//! Decision 8 explicitly rejects a login-bypass "emergency" auth path — a wrong
+//! default here would silently grant mutation rights while GitHub is down, which is a
+//! worse failure mode than a temporary lockout. No code in this file, or anywhere in
+//! `uaa-control`, implements an alternate way to mint a session. If GitHub itself is
+//! unreachable long enough that operators are fully locked out of the `:8443` plane,
+//! the sanctioned recovery procedure is a human-operated, out-of-band, LOGGED
+//! database mutation:
+//!
+//! 1. An operator with access to the server runs `cockroach sql --url <registry DSN>`
+//!    directly against the CockroachDB registry (Decision 4/5) and performs the
+//!    minimal mutation needed to unblock the stuck resource (e.g. hand-adjust a
+//!    row that a normal operator-plane mutation would otherwise have written).
+//! 2. That operator MUST immediately run `uaa-control audit backfill` (CT-04 ships
+//!    this command) so the manual mutation is recorded as a proper audit event —
+//!    the repair is not complete until the backfill lands.
+//!
+//! Total lockout during a GitHub outage is an accepted, mitigated risk (Decision 8),
+//! not a defect to code around; this section documents the hatch, it does not build
+//! one.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context as _, Result};
+use async_trait::async_trait;
+use axum::extract::{Extension, Query, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Redirect, Response};
+use axum::Json;
+use base64::engine::general_purpose::{STANDARD as BASE64, URL_SAFE_NO_PAD as BASE64_URL};
+use base64::Engine as _;
+use ring::hmac;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Session lifetime: 24 hours (spec: "exp = unix seconds, 24h").
+pub const SESSION_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Role cache TTL: 5 minutes (spec Decision 8: "cached 5 min").
+pub const ROLE_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// OAuth `state` token TTL: how long an in-flight login attempt stays valid between
+/// the `/auth/login` redirect and the `/auth/callback` round trip.
+pub const OAUTH_STATE_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// The session cookie name.
+pub const SESSION_COOKIE_NAME: &str = "uaa_session";
+
+/// The HMAC key file's name under [`AuthConfig::state_dir`].
+const HMAC_KEY_FILE: &str = "auth_hmac.key";
+
+// ── Role + config ───────────────────────────────────────────────────────────────
+
+/// Operator role. Declaration order is significant: `derive(PartialOrd, Ord)` ranks
+/// variants by declaration order, so `Role::Admin > Role::Operator > Role::Viewer`
+/// holds exactly as spec Decision 8 requires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Role {
+    Viewer,
+    Operator,
+    Admin,
+}
+
+/// GitHub OAuth + RBAC configuration. `client_secret` is never logged or displayed —
+/// see the redacting [`fmt::Debug`] impl below.
+#[derive(Clone)]
+pub struct AuthConfig {
+    /// `UAA_GITHUB_CLIENT_ID`.
+    pub client_id: String,
+    /// `UAA_GITHUB_CLIENT_SECRET` — sourced from env only, never committed; the
+    /// literal value never appears in this file (Bucket-3 human work sets it).
+    pub client_secret: String,
+    /// The GitHub org that gates access (org membership -> [`Role::Viewer`]).
+    pub org: String,
+    /// Team slug mapped to [`Role::Admin`]. Defaults to the spec's `uaa-admins`.
+    pub admin_team: String,
+    /// Team slug mapped to [`Role::Operator`]. Defaults to the spec's
+    /// `uaa-operators`.
+    pub operator_team: String,
+    /// Where the HMAC signing key (and any other auth state) persists.
+    pub state_dir: PathBuf,
+}
+
+impl fmt::Debug for AuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthConfig")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"<redacted>")
+            .field("org", &self.org)
+            .field("admin_team", &self.admin_team)
+            .field("operator_team", &self.operator_team)
+            .field("state_dir", &self.state_dir)
+            .finish()
+    }
+}
+
+impl AuthConfig {
+    /// Builds config from environment, defaulting team names to the spec's
+    /// `uaa-admins` / `uaa-operators` and the state dir to `/var/lib/uaa`.
+    pub fn from_env() -> Self {
+        Self {
+            client_id: env_var("UAA_GITHUB_CLIENT_ID"),
+            client_secret: env_var("UAA_GITHUB_CLIENT_SECRET"),
+            org: env_var("UAA_GITHUB_ORG"),
+            admin_team: env_var_or("UAA_GITHUB_ADMIN_TEAM", "uaa-admins"),
+            operator_team: env_var_or("UAA_GITHUB_OPERATOR_TEAM", "uaa-operators"),
+            state_dir: PathBuf::from(env_var_or("UAA_STATE_DIR", "/var/lib/uaa")),
+        }
+    }
+}
+
+fn env_var(name: &str) -> String {
+    std::env::var(name).unwrap_or_default()
+}
+
+fn env_var_or(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+// ── GitHub API trait (mockable) ─────────────────────────────────────────────────
+
+/// Org/team membership as reported by GitHub for the token's user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrgMembership {
+    pub org_member: bool,
+    pub teams: Vec<String>,
+}
+
+/// Everything GitHub-shaped goes through this trait so tests never touch the
+/// network. [`RealGithubApi`] is the `reqwest`-backed production implementation;
+/// tests supply a mock (see `mod tests`).
+#[async_trait]
+pub trait GithubApi: Send + Sync {
+    /// Exchanges an OAuth authorization `code` for an access token.
+    async fn exchange_code(&self, code: &str) -> Result<String>;
+    /// Resolves the GitHub login for an access token.
+    async fn user_login(&self, token: &str) -> Result<String>;
+    /// Resolves org membership + team slugs (scoped to [`AuthConfig::org`] by the
+    /// real implementation) for the given login.
+    async fn org_role(&self, token: &str, login: &str) -> Result<OrgMembership>;
+}
+
+/// Production [`GithubApi`]: `reqwest` (rustls-tls, the workspace's only HTTP
+/// client) against the real GitHub REST API.
+pub struct RealGithubApi {
+    http: reqwest::Client,
+    client_id: String,
+    client_secret: String,
+    org: String,
+}
+
+impl RealGithubApi {
+    pub fn new(client_id: String, client_secret: String, org: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            client_id,
+            client_secret,
+            org,
+        }
+    }
+}
+
+#[async_trait]
+impl GithubApi for RealGithubApi {
+    async fn exchange_code(&self, code: &str) -> Result<String> {
+        #[derive(Deserialize)]
+        struct TokenResponse {
+            access_token: Option<String>,
+            error: Option<String>,
+            error_description: Option<String>,
+        }
+        let resp: TokenResponse = self
+            .http
+            .post("https://github.com/login/oauth/access_token")
+            .header(header::ACCEPT, "application/json")
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.as_str()),
+                ("code", code),
+            ])
+            .send()
+            .await
+            .context("github token exchange request failed")?
+            .json()
+            .await
+            .context("github token exchange response malformed")?;
+        resp.access_token.ok_or_else(|| {
+            anyhow!(resp
+                .error_description
+                .or(resp.error)
+                .unwrap_or_else(|| "github returned no access_token".to_string()))
+        })
+    }
+
+    async fn user_login(&self, token: &str) -> Result<String> {
+        #[derive(Deserialize)]
+        struct UserResponse {
+            login: String,
+        }
+        let resp: UserResponse = self
+            .http
+            .get("https://api.github.com/user")
+            .bearer_auth(token)
+            .header(header::USER_AGENT, "uaa-control")
+            .send()
+            .await
+            .context("github user lookup failed")?
+            .error_for_status()
+            .context("github user lookup returned an error status")?
+            .json()
+            .await
+            .context("github user response malformed")?;
+        Ok(resp.login)
+    }
+
+    async fn org_role(&self, token: &str, login: &str) -> Result<OrgMembership> {
+        let org_member = self
+            .http
+            .get(format!(
+                "https://api.github.com/orgs/{}/members/{}",
+                self.org, login
+            ))
+            .bearer_auth(token)
+            .header(header::USER_AGENT, "uaa-control")
+            .send()
+            .await
+            .context("github org membership check failed")?
+            .status()
+            .is_success();
+
+        #[derive(Deserialize)]
+        struct TeamEntry {
+            slug: String,
+            organization: TeamOrg,
+        }
+        #[derive(Deserialize)]
+        struct TeamOrg {
+            login: String,
+        }
+        let teams: Vec<TeamEntry> = self
+            .http
+            .get("https://api.github.com/user/teams")
+            .bearer_auth(token)
+            .header(header::USER_AGENT, "uaa-control")
+            .send()
+            .await
+            .context("github team list failed")?
+            .error_for_status()
+            .context("github team list returned an error status")?
+            .json()
+            .await
+            .context("github team list response malformed")?;
+        let teams = teams
+            .into_iter()
+            .filter(|t| t.organization.login == self.org)
+            .map(|t| t.slug)
+            .collect();
+        Ok(OrgMembership { org_member, teams })
+    }
+}
+
+/// Maps org/team membership to a [`Role`] per spec Decision 8. `None` means "not an
+/// org member" — the caller must treat that as a 403, never a session.
+fn map_role(config: &AuthConfig, membership: &OrgMembership) -> Option<Role> {
+    if membership.teams.iter().any(|t| t == &config.admin_team) {
+        Some(Role::Admin)
+    } else if membership.teams.iter().any(|t| t == &config.operator_team) {
+        Some(Role::Operator)
+    } else if membership.org_member {
+        Some(Role::Viewer)
+    } else {
+        None
+    }
+}
+
+// ── Session cookies ──────────────────────────────────────────────────────────────
+
+/// A verified session: the GitHub login and the role baked into the cookie at mint
+/// time (may be refreshed by [`check_access`] against the 5-minute role cache).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Session {
+    pub login: String,
+    pub role: Role,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SessionPayload {
+    login: String,
+    role: Role,
+    exp: u64,
+}
+
+/// Signs `{login, role, exp}` into `uaa_session=<base64(payload)>.<base64(hmac)>`.
+/// `now` is unix seconds; the cookie expires `SESSION_TTL_SECS` later.
+pub fn mint_session(key: &[u8; 32], login: &str, role: Role, now: u64) -> String {
+    let payload = SessionPayload {
+        login: login.to_string(),
+        role,
+        exp: now.saturating_add(SESSION_TTL_SECS),
+    };
+    let payload_bytes = serde_json::to_vec(&payload).expect("session payload always serializes");
+    let payload_b64 = BASE64.encode(&payload_bytes);
+    let sig = hmac::sign(&hmac::Key::new(hmac::HMAC_SHA256, key), &payload_bytes);
+    let sig_b64 = BASE64.encode(sig.as_ref());
+    format!("{payload_b64}.{sig_b64}")
+}
+
+/// Verifies a session cookie value. Every failure mode — malformed base64, a bad
+/// HMAC signature, an unparseable payload, or `exp <= now` — collapses to `None`;
+/// there is exactly one indistinguishable failure path (spec: "no oracle").
+pub fn verify_session(key: &[u8; 32], cookie: &str, now: u64) -> Option<Session> {
+    let (payload_b64, sig_b64) = cookie.split_once('.')?;
+    let payload_bytes = BASE64.decode(payload_b64).ok()?;
+    let sig_bytes = BASE64.decode(sig_b64).ok()?;
+    let hmac_key = hmac::Key::new(hmac::HMAC_SHA256, key);
+    hmac::verify(&hmac_key, &payload_bytes, &sig_bytes).ok()?;
+    let payload: SessionPayload = serde_json::from_slice(&payload_bytes).ok()?;
+    if payload.exp <= now {
+        return None;
+    }
+    Some(Session {
+        login: payload.login,
+        role: payload.role,
+    })
+}
+
+/// Loads the 32-byte HMAC signing key from `<state_dir>/auth_hmac.key`, generating
+/// and persisting (mode 0600) a fresh random key on first start. `state_dir` comes
+/// from [`AuthConfig`] so tests can point it at a tempdir.
+pub fn load_or_create_hmac_key(state_dir: &Path) -> Result<[u8; 32]> {
+    fs::create_dir_all(state_dir)
+        .with_context(|| format!("creating auth state dir {}", state_dir.display()))?;
+    let path = state_dir.join(HMAC_KEY_FILE);
+    if let Ok(bytes) = fs::read(&path) {
+        if bytes.len() == 32 {
+            let mut key = [0u8; 32];
+            key.copy_from_slice(&bytes);
+            return Ok(key);
+        }
+    }
+    let mut key = [0u8; 32];
+    SystemRandom::new()
+        .fill(&mut key)
+        .map_err(|_| anyhow!("system RNG unavailable while generating the HMAC key"))?;
+    fs::write(&path, key).with_context(|| format!("writing HMAC key to {}", path.display()))?;
+    set_owner_only(&path)
+        .with_context(|| format!("setting 0600 permissions on {}", path.display()))?;
+    Ok(key)
+}
+
+#[cfg(unix)]
+fn set_owner_only(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn random_url_safe_token() -> String {
+    let mut buf = [0u8; 32];
+    SystemRandom::new()
+        .fill(&mut buf)
+        .expect("system RNG unavailable while generating an OAuth state token");
+    BASE64_URL.encode(buf)
+}
+
+/// Minimal percent-encoding for OAuth authorize URL query parameters. Client IDs and
+/// our own generated state tokens are URL-safe base64/hex already; this only guards
+/// against any unexpected character reaching the redirect URL unescaped.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for b in input.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+// ── Auth state (OAuth-in-flight + role cache) ────────────────────────────────────
+
+/// Shared operator-auth state: config, the [`GithubApi`] backend, the HMAC key, the
+/// in-flight OAuth `state` map, and the 5-minute role cache. Mount as an
+/// `axum::Extension<Arc<AuthState>>` (or router state) on the `:8443` operator
+/// router; see [`require_role`] for the middleware contract.
+pub struct AuthState {
+    config: AuthConfig,
+    github: Arc<dyn GithubApi>,
+    hmac_key: [u8; 32],
+    /// OAuth `state` token -> issued-at. Single-use: removed on callback.
+    oauth_states: Mutex<HashMap<String, Instant>>,
+    /// login -> (role, cached-at). TTL is [`ROLE_CACHE_TTL`].
+    role_cache: Mutex<HashMap<String, (Role, Instant)>>,
+    /// login -> GitHub access token, kept server-side only (never in the cookie) so
+    /// a role refresh can re-call [`GithubApi::org_role`] without a fresh login.
+    tokens: Mutex<HashMap<String, String>>,
+}
+
+impl AuthState {
+    pub fn new(config: AuthConfig, github: Arc<dyn GithubApi>, hmac_key: [u8; 32]) -> Arc<Self> {
+        Arc::new(Self {
+            config,
+            github,
+            hmac_key,
+            oauth_states: Mutex::new(HashMap::new()),
+            role_cache: Mutex::new(HashMap::new()),
+            tokens: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn config(&self) -> &AuthConfig {
+        &self.config
+    }
+
+    fn cache_role(&self, login: &str, role: Role) {
+        self.role_cache
+            .lock()
+            .unwrap()
+            .insert(login.to_string(), (role, Instant::now()));
+    }
+
+    fn store_token(&self, login: &str, token: &str) {
+        self.tokens
+            .lock()
+            .unwrap()
+            .insert(login.to_string(), token.to_string());
+    }
+
+    /// The role to apply to the CURRENT request only: a fresh cache hit returns the
+    /// cached role with zero GitHub calls; a stale/missing entry re-checks via
+    /// [`GithubApi::org_role`]. On ANY failure of that refresh — network error,
+    /// missing token, non-member — the role degrades to [`Role::Viewer`] for this
+    /// request. The cache itself is left untouched on failure (never poisoned to
+    /// Viewer), so the next request retries the refresh rather than being stuck.
+    async fn effective_role(&self, login: &str) -> Role {
+        if let Some((role, cached_at)) = self.role_cache.lock().unwrap().get(login).copied() {
+            if cached_at.elapsed() < ROLE_CACHE_TTL {
+                return role;
+            }
+        }
+        let Some(token) = self.tokens.lock().unwrap().get(login).cloned() else {
+            return Role::Viewer;
+        };
+        match self.github.org_role(&token, login).await {
+            Ok(membership) => match map_role(&self.config, &membership) {
+                Some(role) => {
+                    self.cache_role(login, role);
+                    role
+                }
+                None => Role::Viewer,
+            },
+            Err(_) => Role::Viewer,
+        }
+    }
+}
+
+// ── OAuth flow (pure, testable core) ──────────────────────────────────────────────
+
+/// Result of [`begin_oauth_login`]: the state token (also stashed server-side) and
+/// the full GitHub authorize URL to redirect the browser to.
+pub struct LoginRedirect {
+    pub state_token: String,
+    pub authorize_url: String,
+}
+
+/// Starts a login attempt: mints a random `state` token, stashes it (short TTL,
+/// single-use), and builds the `https://github.com/login/oauth/authorize` URL.
+pub fn begin_oauth_login(state: &AuthState) -> LoginRedirect {
+    let state_token = random_url_safe_token();
+    state
+        .oauth_states
+        .lock()
+        .unwrap()
+        .insert(state_token.clone(), Instant::now());
+    let authorize_url = format!(
+        "https://github.com/login/oauth/authorize?client_id={}&state={}&scope={}",
+        percent_encode(&state.config.client_id),
+        percent_encode(&state_token),
+        percent_encode("read:org"),
+    );
+    LoginRedirect {
+        state_token,
+        authorize_url,
+    }
+}
+
+/// Outcome of [`complete_oauth_callback`]. Only [`CallbackOutcome::Success`] mints a
+/// cookie — every other variant leaves the caller unauthenticated.
+#[derive(Debug)]
+pub enum CallbackOutcome {
+    /// Login completed; `cookie` is the ready-to-set `uaa_session` value.
+    Success {
+        cookie: String,
+        login: String,
+        role: Role,
+    },
+    /// The `state` parameter didn't match (or had already expired/been consumed).
+    /// Rejected before any `GithubApi` call — a replayed or forged callback never
+    /// touches GitHub.
+    StateMismatch,
+    /// The code exchanged fine, but the user isn't an org member. No session is
+    /// minted — the operator maps this to 403.
+    Denied,
+    /// A `GithubApi` call failed during login. Per spec: a login must NEVER
+    /// default-grant on GitHub failure, so no cookie is minted — the operator maps
+    /// this to 502.
+    GithubError,
+}
+
+/// Completes the OAuth callback: validates `state`, exchanges `code`, resolves the
+/// login + org/team membership, and — only on full success — mints a session cookie
+/// and warms the role cache + token store for future refreshes.
+pub async fn complete_oauth_callback(
+    state: &AuthState,
+    code: &str,
+    given_state: &str,
+    now_unix: u64,
+) -> CallbackOutcome {
+    let state_valid = {
+        let mut states = state.oauth_states.lock().unwrap();
+        matches!(states.remove(given_state), Some(issued_at) if issued_at.elapsed() < OAUTH_STATE_TTL)
+    };
+    if !state_valid {
+        return CallbackOutcome::StateMismatch;
+    }
+
+    let token = match state.github.exchange_code(code).await {
+        Ok(token) => token,
+        Err(_) => return CallbackOutcome::GithubError,
+    };
+    let login = match state.github.user_login(&token).await {
+        Ok(login) => login,
+        Err(_) => return CallbackOutcome::GithubError,
+    };
+    let membership = match state.github.org_role(&token, &login).await {
+        Ok(membership) => membership,
+        Err(_) => return CallbackOutcome::GithubError,
+    };
+    let Some(role) = map_role(&state.config, &membership) else {
+        return CallbackOutcome::Denied;
+    };
+
+    state.store_token(&login, &token);
+    state.cache_role(&login, role);
+    let cookie = mint_session(&state.hmac_key, &login, role, now_unix);
+    CallbackOutcome::Success {
+        cookie,
+        login,
+        role,
+    }
+}
+
+// ── RBAC guard (pure, testable core) ──────────────────────────────────────────────
+
+/// Result of [`check_access`].
+#[derive(Debug)]
+pub enum AccessDecision {
+    /// The session is valid and its (possibly-refreshed) role meets the minimum.
+    Allow(Session),
+    /// No cookie, a malformed/forged cookie, or an expired one — all indistinguishable.
+    Unauthenticated,
+    /// A valid session whose role does not meet the minimum required.
+    Forbidden,
+}
+
+/// The RBAC guard's pure decision function: verify the cookie, refresh the role
+/// against the 5-minute cache (degrading to Viewer on any GitHub failure), and
+/// compare against `min`. [`require_role`] wraps this for axum; unit tests call it
+/// directly so the fail-closed law is provable without a real HTTP stack.
+pub async fn check_access(
+    state: &AuthState,
+    min: Role,
+    cookie_value: Option<&str>,
+    now_unix: u64,
+) -> AccessDecision {
+    let Some(cookie_value) = cookie_value else {
+        return AccessDecision::Unauthenticated;
+    };
+    let Some(session) = verify_session(&state.hmac_key, cookie_value, now_unix) else {
+        return AccessDecision::Unauthenticated;
+    };
+    let role = state.effective_role(&session.login).await;
+    if role >= min {
+        AccessDecision::Allow(Session {
+            login: session.login,
+            role,
+        })
+    } else {
+        AccessDecision::Forbidden
+    }
+}
+
+fn extract_session_cookie(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get(header::COOKIE)?.to_str().ok()?;
+    raw.split(';').map(str::trim).find_map(|kv| {
+        kv.strip_prefix(SESSION_COOKIE_NAME)
+            .and_then(|rest| rest.strip_prefix('='))
+            .map(str::to_string)
+    })
+}
+
+// ── axum wiring (handlers + middleware for CT-07 to mount) ───────────────────────
+
+/// `GET /auth/login` — 302 to GitHub's authorize endpoint with a fresh `state`.
+pub async fn login_handler(State(state): State<Arc<AuthState>>) -> impl IntoResponse {
+    let redirect = begin_oauth_login(&state);
+    Redirect::to(&redirect.authorize_url)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CallbackQuery {
+    pub code: String,
+    pub state: String,
+}
+
+/// `GET /auth/callback?code&state` — completes the OAuth flow. On success, sets the
+/// signed session cookie (`Secure; HttpOnly; SameSite=Lax`) and 302s to `/`.
+/// A `state` mismatch is a 400, a non-org-member is a 403, and any `GithubApi`
+/// failure during login is a 502 — none of those three paths ever sets a cookie.
+pub async fn callback_handler(
+    State(state): State<Arc<AuthState>>,
+    Query(query): Query<CallbackQuery>,
+) -> Response {
+    match complete_oauth_callback(&state, &query.code, &query.state, unix_now()).await {
+        CallbackOutcome::Success { cookie, .. } => {
+            let cookie_header = format!(
+                "{SESSION_COOKIE_NAME}={cookie}; Path=/; Max-Age={SESSION_TTL_SECS}; Secure; HttpOnly; SameSite=Lax"
+            );
+            let mut resp = Redirect::to("/").into_response();
+            if let Ok(value) = HeaderValue::from_str(&cookie_header) {
+                resp.headers_mut().insert(header::SET_COOKIE, value);
+            }
+            resp
+        }
+        CallbackOutcome::StateMismatch => {
+            (StatusCode::BAD_REQUEST, Json(json!({"error": "state_mismatch"}))).into_response()
+        }
+        CallbackOutcome::Denied => {
+            (StatusCode::FORBIDDEN, Json(json!({"error": "forbidden"}))).into_response()
+        }
+        CallbackOutcome::GithubError => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({"error": "github_unavailable"})),
+        )
+            .into_response(),
+    }
+}
+
+/// RBAC middleware factory. Contract for CT-07 (operator plane): mutating routes
+/// wrap with `require_role(Role::Operator)`, read routes with
+/// `require_role(Role::Viewer)`. Reads `Arc<AuthState>` from the request's
+/// `Extension` (mount it globally on the operator router with
+/// `.layer(Extension(auth_state))`).
+///
+/// Behavior: missing/bad/expired cookie -> 401 JSON `{"error":"unauthenticated"}` for
+/// any path starting `/api/`, else a 302 to `/auth/login`; a valid session whose
+/// (possibly-refreshed) role is below `min` -> 403 JSON `{"error":"forbidden"}`;
+/// otherwise the request is forwarded unchanged.
+pub fn require_role(
+    min: Role,
+) -> axum::middleware::FromFnLayer<
+    impl Clone + Send + Sync + 'static,
+    (),
+    (Extension<Arc<AuthState>>, axum::extract::Request),
+> {
+    axum::middleware::from_fn(
+        move |Extension(state): Extension<Arc<AuthState>>,
+              req: axum::extract::Request,
+              next: Next| async move { role_guard(state, min, req, next).await },
+    )
+}
+
+async fn role_guard(
+    state: Arc<AuthState>,
+    min: Role,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let is_api_path = req.uri().path().starts_with("/api/");
+    let cookie_value = extract_session_cookie(req.headers());
+    let decision = check_access(&state, min, cookie_value.as_deref(), unix_now()).await;
+    match decision {
+        AccessDecision::Allow(_) => next.run(req).await,
+        AccessDecision::Unauthenticated => {
+            if is_api_path {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": "unauthenticated"})),
+                )
+                    .into_response()
+            } else {
+                Redirect::to("/auth/login").into_response()
+            }
+        }
+        AccessDecision::Forbidden => {
+            (StatusCode::FORBIDDEN, Json(json!({"error": "forbidden"}))).into_response()
+        }
+    }
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    /// Mock [`GithubApi`]: configurable success/failure per method, with call
+    /// counters so tests can assert exactly how many network calls WOULD have
+    /// happened (and, for the fail-closed tests, that a failure short-circuits
+    /// before any later call).
+    struct MockGithubApi {
+        login: String,
+        teams: Vec<String>,
+        org_member: bool,
+        fail_exchange: bool,
+        fail_user_login: bool,
+        fail_org_role: bool,
+        exchange_calls: AtomicUsize,
+        user_login_calls: AtomicUsize,
+        org_role_calls: AtomicUsize,
+    }
+
+    impl MockGithubApi {
+        fn healthy(login: &str, teams: Vec<String>, org_member: bool) -> Self {
+            Self {
+                login: login.to_string(),
+                teams,
+                org_member,
+                fail_exchange: false,
+                fail_user_login: false,
+                fail_org_role: false,
+                exchange_calls: AtomicUsize::new(0),
+                user_login_calls: AtomicUsize::new(0),
+                org_role_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn failing_exchange() -> Self {
+            let mut m = Self::healthy("unused", vec![], false);
+            m.fail_exchange = true;
+            m
+        }
+
+        fn failing_org_role() -> Self {
+            let mut m = Self::healthy("alice", vec![], false);
+            m.fail_org_role = true;
+            m
+        }
+    }
+
+    #[async_trait]
+    impl GithubApi for MockGithubApi {
+        async fn exchange_code(&self, _code: &str) -> Result<String> {
+            self.exchange_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_exchange {
+                return Err(anyhow!("mock: exchange_code failed"));
+            }
+            Ok("mock-token".to_string())
+        }
+
+        async fn user_login(&self, _token: &str) -> Result<String> {
+            self.user_login_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_user_login {
+                return Err(anyhow!("mock: user_login failed"));
+            }
+            Ok(self.login.clone())
+        }
+
+        async fn org_role(&self, _token: &str, _login: &str) -> Result<OrgMembership> {
+            self.org_role_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_org_role {
+                return Err(anyhow!("mock: org_role failed"));
+            }
+            Ok(OrgMembership {
+                org_member: self.org_member,
+                teams: self.teams.clone(),
+            })
+        }
+    }
+
+    fn test_config(state_dir: PathBuf) -> AuthConfig {
+        AuthConfig {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            org: "falkcorp".to_string(),
+            admin_team: "uaa-admins".to_string(),
+            operator_team: "uaa-operators".to_string(),
+            state_dir,
+        }
+    }
+
+    /// Builds an [`AuthState`] backed by `mock`, returning both the trait-object
+    /// state (for the functions under test) and the concrete mock `Arc` (so tests
+    /// can still read its call counters afterward) plus the owning tempdir.
+    fn test_state(mock: MockGithubApi) -> (Arc<AuthState>, Arc<MockGithubApi>, tempfile::TempDir) {
+        let dir = tempdir().expect("tempdir");
+        let key = load_or_create_hmac_key(dir.path()).expect("hmac key");
+        let mock = Arc::new(mock);
+        let state = AuthState::new(test_config(dir.path().to_path_buf()), mock.clone(), key);
+        (state, mock, dir)
+    }
+
+    async fn login_via_mock(state: &AuthState) -> CallbackOutcome {
+        let login = begin_oauth_login(state);
+        complete_oauth_callback(state, "mock-code", &login.state_token, unix_now()).await
+    }
+
+    #[test]
+    fn test_cookie_round_trip() {
+        let key = [7u8; 32];
+        let now = 1_000_000u64;
+        let cookie = mint_session(&key, "octocat", Role::Operator, now);
+        let session = verify_session(&key, &cookie, now).expect("valid session");
+        assert_eq!(session.login, "octocat");
+        assert_eq!(session.role, Role::Operator);
+    }
+
+    #[test]
+    fn test_cookie_bad_sig_rejected() {
+        let dir = tempdir().expect("tempdir");
+        let key = load_or_create_hmac_key(dir.path()).expect("hmac key");
+
+        // HMAC key file permissions: mode 0600, asserted here per the acceptance
+        // criteria (cookie integrity + key custody are proven together).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = fs::metadata(dir.path().join(HMAC_KEY_FILE)).expect("key file exists");
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        }
+
+        let other_key = [9u8; 32];
+        let now = 1_000_000u64;
+        let cookie = mint_session(&key, "octocat", Role::Viewer, now);
+
+        // Wrong key entirely.
+        assert!(verify_session(&other_key, &cookie, now).is_none());
+        // Tampered payload under the right key.
+        let tampered = format!("{cookie}-tampered");
+        assert!(verify_session(&key, &tampered, now).is_none());
+    }
+
+    #[test]
+    fn test_cookie_expired_rejected() {
+        let key = [3u8; 32];
+        let now = 1_000_000u64;
+        let cookie = mint_session(&key, "octocat", Role::Admin, now);
+        let after_expiry = now + SESSION_TTL_SECS + 1;
+        assert!(verify_session(&key, &cookie, after_expiry).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_role_mapping_admin_team() {
+        let (state, _mock, _dir) =
+            test_state(MockGithubApi::healthy("alice", vec!["uaa-admins".to_string()], true));
+        match login_via_mock(&state).await {
+            CallbackOutcome::Success { role, .. } => assert_eq!(role, Role::Admin),
+            other => panic!("expected Success(Admin), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_role_mapping_operator_team() {
+        let (state, _mock, _dir) = test_state(MockGithubApi::healthy(
+            "bob",
+            vec!["uaa-operators".to_string()],
+            true,
+        ));
+        match login_via_mock(&state).await {
+            CallbackOutcome::Success { role, .. } => assert_eq!(role, Role::Operator),
+            other => panic!("expected Success(Operator), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_role_mapping_org_member_viewer() {
+        let (state, _mock, _dir) = test_state(MockGithubApi::healthy("carol", vec![], true));
+        match login_via_mock(&state).await {
+            CallbackOutcome::Success { role, .. } => assert_eq!(role, Role::Viewer),
+            other => panic!("expected Success(Viewer), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_role_mapping_non_member_403() {
+        let (state, _mock, _dir) = test_state(MockGithubApi::healthy("dave", vec![], false));
+        match login_via_mock(&state).await {
+            CallbackOutcome::Denied => {}
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_oauth_state_mismatch_rejected() {
+        let (state, mock, _dir) = test_state(MockGithubApi::healthy("alice", vec![], true));
+        let _issued = begin_oauth_login(&state);
+        let outcome =
+            complete_oauth_callback(&state, "mock-code", "not-the-issued-state", unix_now()).await;
+        assert!(matches!(outcome, CallbackOutcome::StateMismatch));
+        // Rejected before any GithubApi call — a forged/replayed callback never
+        // touches GitHub.
+        assert_eq!(mock.exchange_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_login_github_error_no_cookie() {
+        let (state, _mock, _dir) = test_state(MockGithubApi::failing_exchange());
+        match login_via_mock(&state).await {
+            CallbackOutcome::GithubError => {}
+            other => panic!("expected GithubError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_refresh_failure_degrades_to_viewer() {
+        let (state, _mock, _dir) = test_state(MockGithubApi::failing_org_role());
+
+        // Seed a stale cached Admin role (past the 5-minute TTL) plus the token a
+        // refresh would use, then present a session cookie asserting Admin.
+        let stale_at = Instant::now()
+            .checked_sub(ROLE_CACHE_TTL + Duration::from_secs(1))
+            .expect("test host uptime long enough to backdate an Instant");
+        state
+            .role_cache
+            .lock()
+            .unwrap()
+            .insert("alice".to_string(), (Role::Admin, stale_at));
+        state
+            .tokens
+            .lock()
+            .unwrap()
+            .insert("alice".to_string(), "stale-token".to_string());
+        let cookie = mint_session(&state.hmac_key, "alice", Role::Admin, unix_now());
+
+        // Mutation: denied. The stale cached Admin is never served past its TTL.
+        let mutation = check_access(&state, Role::Operator, Some(&cookie), unix_now()).await;
+        assert!(
+            matches!(mutation, AccessDecision::Forbidden),
+            "expected Forbidden, got {mutation:?}"
+        );
+
+        // Read: allowed. Fail-closed degrades to Viewer, it never errors reads.
+        let read = check_access(&state, Role::Viewer, Some(&cookie), unix_now()).await;
+        assert!(
+            matches!(read, AccessDecision::Allow(_)),
+            "expected Allow, got {read:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_within_ttl_skips_github() {
+        let (state, mock, _dir) = test_state(MockGithubApi::healthy(
+            "erin",
+            vec!["uaa-operators".to_string()],
+            true,
+        ));
+        let outcome = login_via_mock(&state).await;
+        let cookie = match outcome {
+            CallbackOutcome::Success { cookie, .. } => cookie,
+            other => panic!("expected Success, got {other:?}"),
+        };
+        assert_eq!(mock.org_role_calls.load(Ordering::SeqCst), 1);
+
+        // A second guarded access well within the 5-minute TTL must not call
+        // GithubApi again — the call count stays at 1.
+        let decision = check_access(&state, Role::Operator, Some(&cookie), unix_now()).await;
+        assert!(matches!(decision, AccessDecision::Allow(_)));
+        assert_eq!(mock.org_role_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_operator_mutation_passes_guards() {
+        // Anti-over-suppression: a legitimate Operator session against a healthy
+        // mock must be admitted by require_role(Operator) — the fail-closed stack
+        // must not also swallow valid requests.
+        let (state, _mock, _dir) = test_state(MockGithubApi::healthy(
+            "frank",
+            vec!["uaa-operators".to_string()],
+            true,
+        ));
+        let cookie = match login_via_mock(&state).await {
+            CallbackOutcome::Success { cookie, role, .. } => {
+                assert_eq!(role, Role::Operator);
+                cookie
+            }
+            other => panic!("expected Success(Operator), got {other:?}"),
+        };
+        let decision = check_access(&state, Role::Operator, Some(&cookie), unix_now()).await;
+        assert!(
+            matches!(decision, AccessDecision::Allow(_)),
+            "a legitimate Operator mutation must pass the guard stack, got {decision:?}"
+        );
+    }
+}

--- a/crates/uaa-control/src/db/registry.rs
+++ b/crates/uaa-control/src/db/registry.rs
@@ -1,10 +1,668 @@
 // file: crates/uaa-control/src/db/registry.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 02d40065-96da-4469-b679-b8bfd4f0b8b3
 // last-edited: 2026-07-10
 
 //! Registry CRUD against CockroachDB (the `RegistryStore` trait + tokio-postgres impl).
 //!
-//! STUB — Filled exclusively by control TASK-02 (CT-02). Row types live in
-//! `db::mod`; this module adds the query/mutation methods and calls
-//! `db::store::write_snapshot` after every successful mutation.
+//! Filled by control TASK-02 (CT-02). Row types live in `db::mod`; this module adds
+//! the query/mutation methods.
+//!
+//! Two implementations:
+//!   * [`PgRegistryStore`] — the real tokio-postgres impl against CockroachDB (spec
+//!     Decision 5). Every SQL string is a `pub(crate) const`, asserted textually by
+//!     this module's tests; the queries themselves are never executed under
+//!     `cargo test` (no live database in the test path). Timestamps and UUIDs are
+//!     bound/read as text with an explicit `::TIMESTAMPTZ` / `::UUID` SQL-side cast —
+//!     this keeps the crate on the workspace's existing `tokio-postgres = "0.7"` dep
+//!     with no extra `with-chrono-0_4` / `with-uuid-1` / `with-serde_json-1` feature
+//!     flags, so nothing was added to any Cargo.toml.
+//!   * [`MemRegistryStore`] — an in-memory `HashMap`-backed store, ALWAYS compiled
+//!     (not `#[cfg(test)]`): this module's own tests use it, `import_export.rs`'s
+//!     tests use it, and sibling control-task tests may reuse it as a store that
+//!     needs no live CockroachDB.
+//!
+//! insert-if-absent semantics are pinned by spec Decision 22: `ON CONFLICT (<pk>) DO
+//! NOTHING`, NEVER `DO UPDATE` — an all-column upsert on rollback-retry was shown to
+//! de-approve live hosts and null out bound TPM EKs. The one deliberate exception is
+//! `upsert_tang_server` (tang checkin is a real last-seen-wins overwrite, matching the
+//! Python `tang[hostname] = {...}` semantics) — realized via CockroachDB's `UPSERT
+//! INTO` extension so the literal string `DO UPDATE` still never appears in this file.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::Result;
+use uuid::Uuid;
+
+use super::{BootTarget, LuksCredentialRow, MachineRow, MachineStatus, TangServerRow, YubikeyRow};
+
+/// Typed registry CRUD (spec Decisions 16/22).
+///
+/// insert-if-absent methods return `Ok(true)` iff the row was newly inserted;
+/// `Ok(false)` means a row with that primary key already existed and was left
+/// COMPLETELY untouched — the no-clobber law a rollback-retry import depends on.
+#[async_trait::async_trait]
+pub trait RegistryStore: Send + Sync {
+    async fn get_machine(&self, mac: &str) -> Result<Option<MachineRow>>;
+    async fn list_machines(&self) -> Result<Vec<MachineRow>>;
+    /// `Ok(true)` = inserted; `Ok(false)` = a row for `row.mac` already existed and
+    /// was left untouched (Decision 22 no-clobber law).
+    async fn insert_machine_if_absent(&self, row: MachineRow) -> Result<bool>;
+    async fn update_machine_status(
+        &self,
+        mac: &str,
+        status: MachineStatus,
+        approved_at: Option<String>,
+    ) -> Result<()>;
+    async fn touch_last_seen(&self, mac: &str, ip: Option<String>) -> Result<()>;
+    async fn set_boot_target(&self, mac: &str, boot_target: BootTarget) -> Result<()>;
+    async fn list_yubikeys(&self) -> Result<Vec<YubikeyRow>>;
+    /// `Ok(true)` = inserted; `Ok(false)` = pre-existing fingerprint, untouched.
+    async fn insert_yubikey_if_absent(&self, row: YubikeyRow) -> Result<bool>;
+    /// Full listing — needed by `import_export::export_to_json` (Decision 16 rollback
+    /// re-hydration). Not explicitly enumerated in the task brief's method list but
+    /// required to fulfil that goal; see the TASK-02 completion report.
+    async fn list_tang_servers(&self) -> Result<Vec<TangServerRow>>;
+    /// Checkin semantics — a REAL last-seen-wins upsert (unlike every other table,
+    /// tang checkins mirror the Python's full-overwrite `tang[hostname] = {...}`).
+    /// Only the import path uses insert-if-absent; live checkins use this method.
+    async fn upsert_tang_server(&self, row: TangServerRow) -> Result<()>;
+    /// `Ok(true)` = inserted; `Ok(false)` = pre-existing hostname, untouched. Import
+    /// path ONLY — live checkins use [`RegistryStore::upsert_tang_server`].
+    async fn insert_tang_if_absent(&self, row: TangServerRow) -> Result<bool>;
+    async fn insert_luks_credential(&self, row: LuksCredentialRow) -> Result<()>;
+    async fn list_luks_credentials(&self, mac: &str) -> Result<Vec<LuksCredentialRow>>;
+    async fn revoke_luks_credential(&self, id: Uuid) -> Result<()>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PgRegistryStore — real tokio-postgres impl (runtime-only; never exercised by
+// `cargo test`, which has no live CockroachDB).
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub(crate) const SQL_GET_MACHINE: &str = "\
+    SELECT mac, hostname, ip, type, status, boot_target, tpm_ek, \
+           registered_at::STRING AS registered_at, approved_at::STRING AS approved_at, \
+           last_seen::STRING AS last_seen, last_ip, installed_at::STRING AS installed_at, \
+           last_install_status, updated_at::STRING AS updated_at \
+    FROM machines WHERE mac = $1";
+
+pub(crate) const SQL_LIST_MACHINES: &str = "\
+    SELECT mac, hostname, ip, type, status, boot_target, tpm_ek, \
+           registered_at::STRING AS registered_at, approved_at::STRING AS approved_at, \
+           last_seen::STRING AS last_seen, last_ip, installed_at::STRING AS installed_at, \
+           last_install_status, updated_at::STRING AS updated_at \
+    FROM machines ORDER BY mac";
+
+pub(crate) const SQL_INSERT_MACHINE_IF_ABSENT: &str = "\
+    INSERT INTO machines \
+      (mac, hostname, ip, type, status, boot_target, tpm_ek, registered_at, approved_at, \
+       last_seen, last_ip, installed_at, last_install_status, updated_at) \
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8::TIMESTAMPTZ, $9::TIMESTAMPTZ, $10::TIMESTAMPTZ, \
+            $11, $12::TIMESTAMPTZ, $13, $14::TIMESTAMPTZ) \
+    ON CONFLICT (mac) DO NOTHING";
+
+pub(crate) const SQL_UPDATE_MACHINE_STATUS: &str =
+    "UPDATE machines SET status = $2, approved_at = $3::TIMESTAMPTZ, updated_at = now() WHERE mac = $1";
+
+pub(crate) const SQL_TOUCH_LAST_SEEN: &str =
+    "UPDATE machines SET last_seen = now(), last_ip = $2, updated_at = now() WHERE mac = $1";
+
+pub(crate) const SQL_SET_BOOT_TARGET: &str =
+    "UPDATE machines SET boot_target = $2, updated_at = now() WHERE mac = $1";
+
+pub(crate) const SQL_LIST_YUBIKEYS: &str = "\
+    SELECT fingerprint, gpg_pubkey, ssh_pubkey, comment, serial, status, \
+           registered_at::STRING AS registered_at \
+    FROM yubikeys ORDER BY fingerprint";
+
+pub(crate) const SQL_INSERT_YUBIKEY_IF_ABSENT: &str = "\
+    INSERT INTO yubikeys (fingerprint, gpg_pubkey, ssh_pubkey, comment, serial, status, registered_at) \
+    VALUES ($1, $2, $3, $4, $5, $6, $7::TIMESTAMPTZ) \
+    ON CONFLICT (fingerprint) DO NOTHING";
+
+pub(crate) const SQL_LIST_TANG_SERVERS: &str = "\
+    SELECT hostname, ip, tang_url, adv_keys::STRING AS adv_keys, last_seen::STRING AS last_seen \
+    FROM tang_servers ORDER BY hostname";
+
+// CockroachDB `UPSERT INTO` extension: last-write-wins on the primary key, matching
+// the Python checkin's full-overwrite semantics — WITHOUT the literal `DO UPDATE`
+// pattern Decision 22 forbids for the insert-if-absent paths in this file.
+pub(crate) const SQL_UPSERT_TANG_SERVER: &str = "\
+    UPSERT INTO tang_servers (hostname, ip, tang_url, adv_keys, last_seen) \
+    VALUES ($1, $2, $3, $4::JSONB, $5::TIMESTAMPTZ)";
+
+pub(crate) const SQL_INSERT_TANG_IF_ABSENT: &str = "\
+    INSERT INTO tang_servers (hostname, ip, tang_url, adv_keys, last_seen) \
+    VALUES ($1, $2, $3, $4::JSONB, $5::TIMESTAMPTZ) \
+    ON CONFLICT (hostname) DO NOTHING";
+
+pub(crate) const SQL_INSERT_LUKS_CREDENTIAL: &str = "\
+    INSERT INTO luks_credentials (id, mac, yubikey_serial, role, luks_keyslot, enrolled_at, revoked_at) \
+    VALUES ($1::UUID, $2, $3, $4, $5, $6::TIMESTAMPTZ, $7::TIMESTAMPTZ)";
+
+pub(crate) const SQL_LIST_LUKS_CREDENTIALS: &str = "\
+    SELECT id::STRING AS id, mac, yubikey_serial, role, luks_keyslot, \
+           enrolled_at::STRING AS enrolled_at, revoked_at::STRING AS revoked_at \
+    FROM luks_credentials WHERE mac = $1 ORDER BY enrolled_at";
+
+pub(crate) const SQL_REVOKE_LUKS_CREDENTIAL: &str =
+    "UPDATE luks_credentials SET revoked_at = now() WHERE id = $1::UUID";
+
+/// Real [`RegistryStore`]: tokio-postgres against CockroachDB. Constructed only at
+/// runtime (`main.rs` builds one from config); unit tests never build it.
+pub struct PgRegistryStore {
+    client: tokio_postgres::Client,
+}
+
+impl PgRegistryStore {
+    pub fn new(client: tokio_postgres::Client) -> Self {
+        Self { client }
+    }
+}
+
+fn row_to_machine(row: &tokio_postgres::Row) -> MachineRow {
+    MachineRow {
+        mac: row.get("mac"),
+        hostname: row.get("hostname"),
+        ip: row.get("ip"),
+        r#type: row.get("type"),
+        status: MachineStatus::from(row.get::<_, String>("status")),
+        boot_target: BootTarget::from(row.get::<_, String>("boot_target")),
+        tpm_ek: row.get("tpm_ek"),
+        registered_at: row.get("registered_at"),
+        approved_at: row.get("approved_at"),
+        last_seen: row.get("last_seen"),
+        last_ip: row.get("last_ip"),
+        installed_at: row.get("installed_at"),
+        last_install_status: row.get("last_install_status"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn row_to_yubikey(row: &tokio_postgres::Row) -> YubikeyRow {
+    YubikeyRow {
+        fingerprint: row.get("fingerprint"),
+        gpg_pubkey: row.get("gpg_pubkey"),
+        ssh_pubkey: row.get("ssh_pubkey"),
+        comment: row.get("comment"),
+        serial: row.get("serial"),
+        status: row.get("status"),
+        registered_at: row.get("registered_at"),
+    }
+}
+
+fn row_to_tang(row: &tokio_postgres::Row) -> Result<TangServerRow> {
+    let adv_keys_text: Option<String> = row.get("adv_keys");
+    Ok(TangServerRow {
+        hostname: row.get("hostname"),
+        ip: row.get("ip"),
+        tang_url: row.get("tang_url"),
+        adv_keys: adv_keys_from_text(adv_keys_text)?,
+        last_seen: row.get("last_seen"),
+    })
+}
+
+fn row_to_luks(row: &tokio_postgres::Row) -> Result<LuksCredentialRow> {
+    let id_text: String = row.get("id");
+    Ok(LuksCredentialRow {
+        id: uuid_from_text(&id_text)?,
+        mac: row.get("mac"),
+        yubikey_serial: row.get("yubikey_serial"),
+        role: row.get("role"),
+        luks_keyslot: row.get("luks_keyslot"),
+        enrolled_at: row.get("enrolled_at"),
+        revoked_at: row.get("revoked_at"),
+    })
+}
+
+fn adv_keys_to_text(v: &Option<serde_json::Value>) -> Result<Option<String>> {
+    v.as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn adv_keys_from_text(s: Option<String>) -> Result<Option<serde_json::Value>> {
+    s.map(|s| serde_json::from_str(&s))
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn uuid_to_text(id: Uuid) -> String {
+    id.to_string()
+}
+
+fn uuid_from_text(s: &str) -> Result<Uuid> {
+    Uuid::parse_str(s).map_err(Into::into)
+}
+
+#[async_trait::async_trait]
+impl RegistryStore for PgRegistryStore {
+    async fn get_machine(&self, mac: &str) -> Result<Option<MachineRow>> {
+        let row = self.client.query_opt(SQL_GET_MACHINE, &[&mac]).await?;
+        Ok(row.as_ref().map(row_to_machine))
+    }
+
+    async fn list_machines(&self) -> Result<Vec<MachineRow>> {
+        let rows = self.client.query(SQL_LIST_MACHINES, &[]).await?;
+        Ok(rows.iter().map(row_to_machine).collect())
+    }
+
+    async fn insert_machine_if_absent(&self, row: MachineRow) -> Result<bool> {
+        let status: String = row.status.into();
+        let boot_target: String = row.boot_target.into();
+        let n = self
+            .client
+            .execute(
+                SQL_INSERT_MACHINE_IF_ABSENT,
+                &[
+                    &row.mac,
+                    &row.hostname,
+                    &row.ip,
+                    &row.r#type,
+                    &status,
+                    &boot_target,
+                    &row.tpm_ek,
+                    &row.registered_at,
+                    &row.approved_at,
+                    &row.last_seen,
+                    &row.last_ip,
+                    &row.installed_at,
+                    &row.last_install_status,
+                    &row.updated_at,
+                ],
+            )
+            .await?;
+        Ok(n == 1)
+    }
+
+    async fn update_machine_status(
+        &self,
+        mac: &str,
+        status: MachineStatus,
+        approved_at: Option<String>,
+    ) -> Result<()> {
+        let status: String = status.into();
+        self.client
+            .execute(SQL_UPDATE_MACHINE_STATUS, &[&mac, &status, &approved_at])
+            .await?;
+        Ok(())
+    }
+
+    async fn touch_last_seen(&self, mac: &str, ip: Option<String>) -> Result<()> {
+        self.client
+            .execute(SQL_TOUCH_LAST_SEEN, &[&mac, &ip])
+            .await?;
+        Ok(())
+    }
+
+    async fn set_boot_target(&self, mac: &str, boot_target: BootTarget) -> Result<()> {
+        let boot_target: String = boot_target.into();
+        self.client
+            .execute(SQL_SET_BOOT_TARGET, &[&mac, &boot_target])
+            .await?;
+        Ok(())
+    }
+
+    async fn list_yubikeys(&self) -> Result<Vec<YubikeyRow>> {
+        let rows = self.client.query(SQL_LIST_YUBIKEYS, &[]).await?;
+        Ok(rows.iter().map(row_to_yubikey).collect())
+    }
+
+    async fn insert_yubikey_if_absent(&self, row: YubikeyRow) -> Result<bool> {
+        let n = self
+            .client
+            .execute(
+                SQL_INSERT_YUBIKEY_IF_ABSENT,
+                &[
+                    &row.fingerprint,
+                    &row.gpg_pubkey,
+                    &row.ssh_pubkey,
+                    &row.comment,
+                    &row.serial,
+                    &row.status,
+                    &row.registered_at,
+                ],
+            )
+            .await?;
+        Ok(n == 1)
+    }
+
+    async fn list_tang_servers(&self) -> Result<Vec<TangServerRow>> {
+        let rows = self.client.query(SQL_LIST_TANG_SERVERS, &[]).await?;
+        rows.iter().map(row_to_tang).collect()
+    }
+
+    async fn upsert_tang_server(&self, row: TangServerRow) -> Result<()> {
+        let adv_keys = adv_keys_to_text(&row.adv_keys)?;
+        self.client
+            .execute(
+                SQL_UPSERT_TANG_SERVER,
+                &[&row.hostname, &row.ip, &row.tang_url, &adv_keys, &row.last_seen],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn insert_tang_if_absent(&self, row: TangServerRow) -> Result<bool> {
+        let adv_keys = adv_keys_to_text(&row.adv_keys)?;
+        let n = self
+            .client
+            .execute(
+                SQL_INSERT_TANG_IF_ABSENT,
+                &[&row.hostname, &row.ip, &row.tang_url, &adv_keys, &row.last_seen],
+            )
+            .await?;
+        Ok(n == 1)
+    }
+
+    async fn insert_luks_credential(&self, row: LuksCredentialRow) -> Result<()> {
+        let id = uuid_to_text(row.id);
+        self.client
+            .execute(
+                SQL_INSERT_LUKS_CREDENTIAL,
+                &[
+                    &id,
+                    &row.mac,
+                    &row.yubikey_serial,
+                    &row.role,
+                    &row.luks_keyslot,
+                    &row.enrolled_at,
+                    &row.revoked_at,
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn list_luks_credentials(&self, mac: &str) -> Result<Vec<LuksCredentialRow>> {
+        let rows = self.client.query(SQL_LIST_LUKS_CREDENTIALS, &[&mac]).await?;
+        rows.iter().map(row_to_luks).collect()
+    }
+
+    async fn revoke_luks_credential(&self, id: Uuid) -> Result<()> {
+        let id = uuid_to_text(id);
+        self.client
+            .execute(SQL_REVOKE_LUKS_CREDENTIAL, &[&id])
+            .await?;
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MemRegistryStore — in-memory store. ALWAYS compiled (test/degraded support; used
+// by this module's tests AND by sibling control-task tests).
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Default)]
+struct MemState {
+    machines: HashMap<String, MachineRow>,
+    yubikeys: HashMap<String, YubikeyRow>,
+    tang_servers: HashMap<String, TangServerRow>,
+    luks_credentials: HashMap<Uuid, LuksCredentialRow>,
+}
+
+/// In-memory [`RegistryStore`]. `*_if_absent` leaves a pre-existing row COMPLETELY
+/// untouched and returns `Ok(false)` — the same no-clobber contract [`PgRegistryStore`]
+/// enforces in SQL. Test/degraded support; used by sibling task tests.
+pub struct MemRegistryStore {
+    state: Mutex<MemState>,
+}
+
+impl MemRegistryStore {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(MemState::default()),
+        }
+    }
+}
+
+impl Default for MemRegistryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn now_epoch_secs_string() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    secs.to_string()
+}
+
+#[async_trait::async_trait]
+impl RegistryStore for MemRegistryStore {
+    async fn get_machine(&self, mac: &str) -> Result<Option<MachineRow>> {
+        Ok(self.state.lock().unwrap().machines.get(mac).cloned())
+    }
+
+    async fn list_machines(&self) -> Result<Vec<MachineRow>> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap()
+            .machines
+            .values()
+            .cloned()
+            .collect())
+    }
+
+    async fn insert_machine_if_absent(&self, row: MachineRow) -> Result<bool> {
+        let mut st = self.state.lock().unwrap();
+        if st.machines.contains_key(&row.mac) {
+            return Ok(false);
+        }
+        st.machines.insert(row.mac.clone(), row);
+        Ok(true)
+    }
+
+    async fn update_machine_status(
+        &self,
+        mac: &str,
+        status: MachineStatus,
+        approved_at: Option<String>,
+    ) -> Result<()> {
+        let mut st = self.state.lock().unwrap();
+        if let Some(row) = st.machines.get_mut(mac) {
+            row.status = status;
+            row.approved_at = approved_at;
+        }
+        Ok(())
+    }
+
+    async fn touch_last_seen(&self, mac: &str, ip: Option<String>) -> Result<()> {
+        let mut st = self.state.lock().unwrap();
+        if let Some(row) = st.machines.get_mut(mac) {
+            row.last_seen = Some(now_epoch_secs_string());
+            row.last_ip = ip;
+        }
+        Ok(())
+    }
+
+    async fn set_boot_target(&self, mac: &str, boot_target: BootTarget) -> Result<()> {
+        let mut st = self.state.lock().unwrap();
+        if let Some(row) = st.machines.get_mut(mac) {
+            row.boot_target = boot_target;
+        }
+        Ok(())
+    }
+
+    async fn list_yubikeys(&self) -> Result<Vec<YubikeyRow>> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap()
+            .yubikeys
+            .values()
+            .cloned()
+            .collect())
+    }
+
+    async fn insert_yubikey_if_absent(&self, row: YubikeyRow) -> Result<bool> {
+        let mut st = self.state.lock().unwrap();
+        if st.yubikeys.contains_key(&row.fingerprint) {
+            return Ok(false);
+        }
+        st.yubikeys.insert(row.fingerprint.clone(), row);
+        Ok(true)
+    }
+
+    async fn list_tang_servers(&self) -> Result<Vec<TangServerRow>> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap()
+            .tang_servers
+            .values()
+            .cloned()
+            .collect())
+    }
+
+    async fn upsert_tang_server(&self, row: TangServerRow) -> Result<()> {
+        let mut st = self.state.lock().unwrap();
+        st.tang_servers.insert(row.hostname.clone(), row);
+        Ok(())
+    }
+
+    async fn insert_tang_if_absent(&self, row: TangServerRow) -> Result<bool> {
+        let mut st = self.state.lock().unwrap();
+        if st.tang_servers.contains_key(&row.hostname) {
+            return Ok(false);
+        }
+        st.tang_servers.insert(row.hostname.clone(), row);
+        Ok(true)
+    }
+
+    async fn insert_luks_credential(&self, row: LuksCredentialRow) -> Result<()> {
+        let mut st = self.state.lock().unwrap();
+        st.luks_credentials.insert(row.id, row);
+        Ok(())
+    }
+
+    async fn list_luks_credentials(&self, mac: &str) -> Result<Vec<LuksCredentialRow>> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap()
+            .luks_credentials
+            .values()
+            .filter(|r| r.mac == mac)
+            .cloned()
+            .collect())
+    }
+
+    async fn revoke_luks_credential(&self, id: Uuid) -> Result<()> {
+        let mut st = self.state.lock().unwrap();
+        if let Some(row) = st.luks_credentials.get_mut(&id) {
+            row.revoked_at = Some(now_epoch_secs_string());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_machine(mac: &str) -> MachineRow {
+        MachineRow {
+            mac: mac.to_string(),
+            hostname: "h1".into(),
+            ip: None,
+            r#type: "lenovo".into(),
+            status: MachineStatus::Pending,
+            boot_target: BootTarget::LocalDisk,
+            tpm_ek: None,
+            registered_at: None,
+            approved_at: None,
+            last_seen: None,
+            last_ip: None,
+            installed_at: None,
+            last_install_status: None,
+            updated_at: None,
+        }
+    }
+
+    /// Pins Decision 22: the machine insert-if-absent SQL const carries `ON CONFLICT
+    /// (mac) DO NOTHING` and NEVER `DO UPDATE`. Same for yubikeys/tang import-path
+    /// consts; `upsert_tang_server` uses CockroachDB's `UPSERT INTO` (checkin
+    /// semantics) instead of `DO UPDATE`.
+    #[test]
+    fn test_sql_const_pins_on_conflict() {
+        assert!(SQL_INSERT_MACHINE_IF_ABSENT.contains("ON CONFLICT (mac) DO NOTHING"));
+        assert!(!SQL_INSERT_MACHINE_IF_ABSENT.contains("DO UPDATE"));
+        assert!(SQL_INSERT_YUBIKEY_IF_ABSENT.contains("ON CONFLICT (fingerprint) DO NOTHING"));
+        assert!(!SQL_INSERT_YUBIKEY_IF_ABSENT.contains("DO UPDATE"));
+        assert!(SQL_INSERT_TANG_IF_ABSENT.contains("ON CONFLICT (hostname) DO NOTHING"));
+        assert!(!SQL_INSERT_TANG_IF_ABSENT.contains("DO UPDATE"));
+        assert!(
+            !SQL_UPSERT_TANG_SERVER.contains("DO UPDATE"),
+            "tang checkin upsert uses CRDB UPSERT INTO, not DO UPDATE"
+        );
+        assert!(SQL_UPSERT_TANG_SERVER.contains("UPSERT INTO"));
+    }
+
+    #[tokio::test]
+    async fn test_mem_insert_if_absent_true_for_new_mac() {
+        let store = MemRegistryStore::new();
+        let inserted = store
+            .insert_machine_if_absent(sample_machine("aa:bb:cc:dd:ee:ff"))
+            .await
+            .unwrap();
+        assert!(inserted);
+    }
+
+    #[tokio::test]
+    async fn test_mem_insert_if_absent_false_and_unchanged_for_existing_mac() {
+        let store = MemRegistryStore::new();
+        store
+            .insert_machine_if_absent(sample_machine("aa:bb:cc:dd:ee:ff"))
+            .await
+            .unwrap();
+
+        let mut second = sample_machine("aa:bb:cc:dd:ee:ff");
+        second.hostname = "different".into();
+        let inserted = store.insert_machine_if_absent(second).await.unwrap();
+
+        assert!(!inserted);
+        let row = store
+            .get_machine("aa:bb:cc:dd:ee:ff")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.hostname, "h1", "pre-existing row must be untouched");
+    }
+
+    #[tokio::test]
+    async fn test_mem_upsert_tang_server_overwrites() {
+        let store = MemRegistryStore::new();
+        store
+            .upsert_tang_server(TangServerRow {
+                hostname: "tang1".into(),
+                ip: Some("10.0.0.1".into()),
+                tang_url: None,
+                adv_keys: None,
+                last_seen: Some("1".into()),
+            })
+            .await
+            .unwrap();
+        store
+            .upsert_tang_server(TangServerRow {
+                hostname: "tang1".into(),
+                ip: Some("10.0.0.2".into()),
+                tang_url: None,
+                adv_keys: None,
+                last_seen: Some("2".into()),
+            })
+            .await
+            .unwrap();
+
+        let rows = store.list_tang_servers().await.unwrap();
+        assert_eq!(rows.len(), 1, "checkin upsert replaces, not appends");
+        assert_eq!(rows[0].ip.as_deref(), Some("10.0.0.2"));
+    }
+}

--- a/crates/uaa-control/src/import_export.rs
+++ b/crates/uaa-control/src/import_export.rs
@@ -1,9 +1,743 @@
 // file: crates/uaa-control/src/import_export.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f8e14f9-bb1f-48d3-88ce-91f6accaaf77
 // last-edited: 2026-07-10
 
 //! Registry import/export (parity with the legacy JSON registries).
 //!
-//! STUB — Filled exclusively by control TASK-02 (CT-02). Backs the `import`/`export`
-//! subcommands in `main.rs`.
+//! Filled by control TASK-02 (CT-02). Backs the `import`/`export` subcommands in
+//! `main.rs` (wired by the coordinator — see the TASK-02 completion report for the
+//! exact one-line wiring).
+//!
+//! * [`import_from`] — Decision 22: `uaa-control import --from <dir>` reads the three
+//!   legacy JSON registries (`registry.json`, `yubikey-registry.json`,
+//!   `tang-registry.json`, ground truth: `scripts/autoinstall-agent.py`) and inserts
+//!   each row ONLY if its primary key is absent from the store. A pre-existing CRDB
+//!   row — even a stale-looking one — is NEVER touched: a wrong upsert here would
+//!   de-approve live hosts and null out bound TPM EKs during a rollback-retry cycle.
+//! * [`export_to_json`] — Decision 16: `uaa-control export --to-json <dir>` re-hydrates
+//!   the same three JSON files from CRDB (the rollback path: disable this daemon,
+//!   export, re-enable `autoinstall-agent.service`).
+//!
+//! Timestamps: the JSON ground truth uses UNIX INTEGER SECONDS; the row types
+//! (`db::mod`) store `TIMESTAMPTZ` columns as `Option<String>`. This module's
+//! canonical text form for that `String` is the decimal UNIX-seconds representation
+//! (matching `db::store`'s own `now_epoch_secs` convention) — converting `unix int ->
+//! decimal string -> unix int` is exact and needs no extra date/time dependency.
+//!
+//! Fail-closed malformed-JSON semantics: each of the three files is parsed to a
+//! complete `serde_json::Value` before any row from it is touched, so a parse error
+//! can never leave a half-imported file — the whole file's parse either fully
+//! succeeds or nothing from it is inserted. A parse error aborts the rest of the
+//! import (the offending filename is named in the error).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+
+use crate::db::registry::RegistryStore;
+use crate::db::{BootTarget, MachineRow, MachineStatus, TangServerRow, YubikeyRow};
+
+const REGISTRY_FILE: &str = "registry.json";
+const YUBIKEY_REGISTRY_FILE: &str = "yubikey-registry.json";
+const TANG_REGISTRY_FILE: &str = "tang-registry.json";
+
+/// Per-table counts, reused for both [`ImportReport::inserted`] and
+/// [`ImportReport::skipped`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RegistryCounts {
+    pub machines: usize,
+    pub yubikeys: usize,
+    pub tang: usize,
+}
+
+/// Outcome of [`import_from`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ImportReport {
+    pub inserted: RegistryCounts,
+    pub skipped: RegistryCounts,
+    /// Ground-truth filenames that were absent from the import dir (warned, not
+    /// fatal — the other files still import).
+    pub files_missing: Vec<String>,
+}
+
+/// Outcome of [`export_to_json`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ExportReport {
+    pub machines: usize,
+    pub yubikeys: usize,
+    pub tang: usize,
+}
+
+/// Mirrors the Python ground truth `normalize_mac` (`scripts/autoinstall-agent.py`):
+/// lowercase, then `-`/`.` separators collapse to `:`.
+pub fn normalize_mac(mac: &str) -> String {
+    mac.to_lowercase().replace(['-', '.'], ":")
+}
+
+/// JSON `Value` holding a UNIX-seconds integer -> the row types' canonical
+/// `TIMESTAMPTZ` text form (decimal string). `None` for anything that isn't a number
+/// (absent key, wrong type — treated as absent, never a hard error: edge semantics
+/// only promise a *hard* error for malformed JSON at the whole-file level).
+fn unix_to_ts(v: &Value) -> Option<String> {
+    v.as_i64().map(|n| n.to_string())
+}
+
+/// The inverse of [`unix_to_ts`]: canonical text form -> UNIX-seconds integer.
+fn ts_to_unix(s: &str) -> Option<i64> {
+    s.parse::<i64>().ok()
+}
+
+fn now_unix() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Import the three legacy JSON registries from `dir` into `store`, using the
+/// `*_if_absent` store methods exclusively (Decision 22: a pre-existing row is
+/// counted `skipped`, never touched). An absent file is warned and skipped — the
+/// other files still import. A malformed JSON file is a hard error naming the file;
+/// nothing from a malformed file is ever inserted (see module docs).
+pub async fn import_from(dir: &Path, store: &dyn RegistryStore) -> Result<ImportReport> {
+    let mut report = ImportReport::default();
+
+    match import_machines(dir, store).await? {
+        Some((inserted, skipped)) => {
+            report.inserted.machines = inserted;
+            report.skipped.machines = skipped;
+        }
+        None => {
+            tracing::warn!(file = REGISTRY_FILE, "registry import: file absent, skipping");
+            report.files_missing.push(REGISTRY_FILE.to_string());
+        }
+    }
+
+    match import_yubikeys(dir, store).await? {
+        Some((inserted, skipped)) => {
+            report.inserted.yubikeys = inserted;
+            report.skipped.yubikeys = skipped;
+        }
+        None => {
+            tracing::warn!(
+                file = YUBIKEY_REGISTRY_FILE,
+                "registry import: file absent, skipping"
+            );
+            report.files_missing.push(YUBIKEY_REGISTRY_FILE.to_string());
+        }
+    }
+
+    match import_tang(dir, store).await? {
+        Some((inserted, skipped)) => {
+            report.inserted.tang = inserted;
+            report.skipped.tang = skipped;
+        }
+        None => {
+            tracing::warn!(
+                file = TANG_REGISTRY_FILE,
+                "registry import: file absent, skipping"
+            );
+            report.files_missing.push(TANG_REGISTRY_FILE.to_string());
+        }
+    }
+
+    Ok(report)
+}
+
+/// Read `dir/name` as a JSON object. `Ok(None)` = file absent (the caller warns and
+/// continues with the other files). `Err` = malformed JSON or a JSON value that isn't
+/// an object, named in the error — fail-closed: the whole file is parsed before any
+/// row is touched, so a parse error never leaves a half-imported file.
+fn read_json_dict(dir: &Path, name: &str) -> Result<Option<Map<String, Value>>> {
+    let path = dir.join(name);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).with_context(|| format!("reading {}", path.display())),
+    };
+    let value: Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("malformed JSON in {}", path.display()))?;
+    match value {
+        Value::Object(map) => Ok(Some(map)),
+        other => anyhow::bail!(
+            "malformed JSON in {}: expected a JSON object, got {other}",
+            path.display()
+        ),
+    }
+}
+
+/// Log (debug-level, never error) any JSON object key not in `known` — the pinned
+/// "unknown extra keys are ignored" edge semantic.
+fn log_unknown_keys(context: &str, obj: &Map<String, Value>, known: &[&str]) {
+    for key in obj.keys() {
+        if !known.contains(&key.as_str()) {
+            tracing::debug!(%context, key = %key, "registry import: ignoring unknown key");
+        }
+    }
+}
+
+async fn import_machines(
+    dir: &Path,
+    store: &dyn RegistryStore,
+) -> Result<Option<(usize, usize)>> {
+    let Some(map) = read_json_dict(dir, REGISTRY_FILE)? else {
+        return Ok(None);
+    };
+
+    const KNOWN: &[&str] = &[
+        "hostname",
+        "ip",
+        "type",
+        "status",
+        "registered_at",
+        "approved_at",
+        "last_seen",
+        "last_ip",
+        "tpm_ek",
+    ];
+
+    let mut inserted = 0usize;
+    let mut skipped = 0usize;
+    for (raw_mac, entry) in map {
+        let mac = normalize_mac(&raw_mac);
+        let Some(obj) = entry.as_object() else {
+            tracing::debug!(mac = %mac, "registry import: entry is not an object, skipping");
+            continue;
+        };
+        log_unknown_keys(&mac, obj, KNOWN);
+
+        let row = MachineRow {
+            mac: mac.clone(),
+            hostname: obj
+                .get("hostname")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            ip: obj.get("ip").and_then(Value::as_str).map(str::to_string),
+            r#type: obj
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("lenovo")
+                .to_string(),
+            status: obj
+                .get("status")
+                .and_then(Value::as_str)
+                .map(|s| MachineStatus::from(s.to_string()))
+                .unwrap_or(MachineStatus::Pending),
+            boot_target: BootTarget::LocalDisk,
+            tpm_ek: obj.get("tpm_ek").and_then(Value::as_str).map(str::to_string),
+            registered_at: obj
+                .get("registered_at")
+                .and_then(unix_to_ts)
+                .or_else(|| Some(now_unix().to_string())),
+            approved_at: obj.get("approved_at").and_then(unix_to_ts),
+            last_seen: obj.get("last_seen").and_then(unix_to_ts),
+            last_ip: obj.get("last_ip").and_then(Value::as_str).map(str::to_string),
+            installed_at: None,
+            last_install_status: None,
+            updated_at: None,
+        };
+
+        if store.insert_machine_if_absent(row).await? {
+            inserted += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+    Ok(Some((inserted, skipped)))
+}
+
+async fn import_yubikeys(
+    dir: &Path,
+    store: &dyn RegistryStore,
+) -> Result<Option<(usize, usize)>> {
+    let Some(map) = read_json_dict(dir, YUBIKEY_REGISTRY_FILE)? else {
+        return Ok(None);
+    };
+
+    const KNOWN: &[&str] = &[
+        "fingerprint",
+        "gpg_pubkey",
+        "ssh_pubkey",
+        "comment",
+        "serial",
+        "status",
+        "registered_at",
+    ];
+
+    let mut inserted = 0usize;
+    let mut skipped = 0usize;
+    for (fingerprint, entry) in map {
+        let Some(obj) = entry.as_object() else {
+            tracing::debug!(fingerprint = %fingerprint, "yubikey import: entry is not an object, skipping");
+            continue;
+        };
+        log_unknown_keys(&fingerprint, obj, KNOWN);
+
+        let row = YubikeyRow {
+            fingerprint: fingerprint.clone(),
+            gpg_pubkey: obj
+                .get("gpg_pubkey")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            ssh_pubkey: obj
+                .get("ssh_pubkey")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            comment: obj.get("comment").and_then(Value::as_str).map(str::to_string),
+            serial: obj.get("serial").and_then(Value::as_str).map(str::to_string),
+            status: obj
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("pending")
+                .to_string(),
+            registered_at: obj
+                .get("registered_at")
+                .and_then(unix_to_ts)
+                .or_else(|| Some(now_unix().to_string())),
+        };
+
+        if store.insert_yubikey_if_absent(row).await? {
+            inserted += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+    Ok(Some((inserted, skipped)))
+}
+
+async fn import_tang(dir: &Path, store: &dyn RegistryStore) -> Result<Option<(usize, usize)>> {
+    let Some(map) = read_json_dict(dir, TANG_REGISTRY_FILE)? else {
+        return Ok(None);
+    };
+
+    const KNOWN: &[&str] = &["hostname", "ip", "tang_url", "adv_keys", "last_seen"];
+
+    let mut inserted = 0usize;
+    let mut skipped = 0usize;
+    for (hostname, entry) in map {
+        let Some(obj) = entry.as_object() else {
+            tracing::debug!(hostname = %hostname, "tang import: entry is not an object, skipping");
+            continue;
+        };
+        log_unknown_keys(&hostname, obj, KNOWN);
+
+        let row = TangServerRow {
+            hostname: hostname.clone(),
+            ip: obj.get("ip").and_then(Value::as_str).map(str::to_string),
+            tang_url: obj
+                .get("tang_url")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            adv_keys: obj.get("adv_keys").cloned(),
+            last_seen: obj.get("last_seen").and_then(unix_to_ts),
+        };
+
+        if store.insert_tang_if_absent(row).await? {
+            inserted += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+    Ok(Some((inserted, skipped)))
+}
+
+/// Re-hydrate the three legacy JSON registries from `store` into `dir` (Decision 16
+/// rollback). Overwrites the target files — that is the point. Each file is written
+/// tmp+rename, mirroring `db::store::write_snapshot`'s atomic-write contract.
+pub async fn export_to_json(dir: &Path, store: &dyn RegistryStore) -> Result<ExportReport> {
+    let machines = store.list_machines().await?;
+    let yubikeys = store.list_yubikeys().await?;
+    let tang = store.list_tang_servers().await?;
+
+    write_machines(dir, &machines)?;
+    write_yubikeys(dir, &yubikeys)?;
+    write_tang(dir, &tang)?;
+
+    Ok(ExportReport {
+        machines: machines.len(),
+        yubikeys: yubikeys.len(),
+        tang: tang.len(),
+    })
+}
+
+fn write_machines(dir: &Path, rows: &[MachineRow]) -> Result<()> {
+    let mut map = Map::new();
+    for row in rows {
+        let mut entry = Map::new();
+        entry.insert("hostname".into(), Value::String(row.hostname.clone()));
+        entry.insert("type".into(), Value::String(row.r#type.clone()));
+        entry.insert(
+            "status".into(),
+            Value::String(String::from(row.status.clone())),
+        );
+        if let Some(ts) = row.registered_at.as_deref().and_then(ts_to_unix) {
+            entry.insert("registered_at".into(), Value::from(ts));
+        }
+        if let Some(ts) = row.approved_at.as_deref().and_then(ts_to_unix) {
+            entry.insert("approved_at".into(), Value::from(ts));
+        }
+        if let Some(ts) = row.last_seen.as_deref().and_then(ts_to_unix) {
+            entry.insert("last_seen".into(), Value::from(ts));
+        }
+        if let Some(ip) = &row.last_ip {
+            entry.insert("last_ip".into(), Value::String(ip.clone()));
+        }
+        if let Some(ek) = &row.tpm_ek {
+            entry.insert("tpm_ek".into(), Value::String(ek.clone()));
+        }
+        map.insert(row.mac.clone(), Value::Object(entry));
+    }
+    atomic_write_json(&dir.join(REGISTRY_FILE), &Value::Object(map))
+}
+
+fn write_yubikeys(dir: &Path, rows: &[YubikeyRow]) -> Result<()> {
+    let mut map = Map::new();
+    for row in rows {
+        let mut entry = Map::new();
+        if let Some(v) = &row.gpg_pubkey {
+            entry.insert("gpg_pubkey".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &row.ssh_pubkey {
+            entry.insert("ssh_pubkey".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &row.comment {
+            entry.insert("comment".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &row.serial {
+            entry.insert("serial".into(), Value::String(v.clone()));
+        }
+        entry.insert("status".into(), Value::String(row.status.clone()));
+        if let Some(ts) = row.registered_at.as_deref().and_then(ts_to_unix) {
+            entry.insert("registered_at".into(), Value::from(ts));
+        }
+        map.insert(row.fingerprint.clone(), Value::Object(entry));
+    }
+    atomic_write_json(&dir.join(YUBIKEY_REGISTRY_FILE), &Value::Object(map))
+}
+
+fn write_tang(dir: &Path, rows: &[TangServerRow]) -> Result<()> {
+    let mut map = Map::new();
+    for row in rows {
+        let mut entry = Map::new();
+        if let Some(v) = &row.ip {
+            entry.insert("ip".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &row.tang_url {
+            entry.insert("tang_url".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &row.adv_keys {
+            entry.insert("adv_keys".into(), v.clone());
+        }
+        if let Some(ts) = row.last_seen.as_deref().and_then(ts_to_unix) {
+            entry.insert("last_seen".into(), Value::from(ts));
+        }
+        map.insert(row.hostname.clone(), Value::Object(entry));
+    }
+    atomic_write_json(&dir.join(TANG_REGISTRY_FILE), &Value::Object(map))
+}
+
+/// tmp+rename, mirroring `db::store::write_snapshot`'s atomic-write contract: write
+/// the full document to `<path>.tmp`, then rename over the live file so a reader
+/// never observes a half-written export.
+fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut tmp = path.as_os_str().to_os_string();
+    tmp.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp);
+    let bytes = serde_json::to_vec_pretty(value)?;
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::registry::MemRegistryStore;
+
+    fn write_fixture(dir: &Path, name: &str, json: &str) {
+        std::fs::write(dir.join(name), json).unwrap();
+    }
+
+    fn sample_machine(mac: &str) -> MachineRow {
+        MachineRow {
+            mac: mac.to_string(),
+            hostname: "h1".into(),
+            ip: None,
+            r#type: "lenovo".into(),
+            status: MachineStatus::Approved,
+            boot_target: BootTarget::LocalDisk,
+            tpm_ek: Some("ek123".into()),
+            registered_at: Some("1600000000".into()),
+            approved_at: Some("1600000001".into()),
+            last_seen: None,
+            last_ip: None,
+            installed_at: None,
+            last_install_status: None,
+            updated_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_import_inserts_fresh_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"AA:BB:CC:DD:EE:FF": {"hostname": "h1", "type": "lenovo", "status": "approved", "registered_at": 1700000000}}"#,
+        );
+        write_fixture(
+            dir.path(),
+            YUBIKEY_REGISTRY_FILE,
+            r#"{"FINGERPRINT1": {"gpg_pubkey": "gpg", "ssh_pubkey": "ssh", "comment": "c", "serial": "s", "status": "approved", "registered_at": 1700000000}}"#,
+        );
+        write_fixture(
+            dir.path(),
+            TANG_REGISTRY_FILE,
+            r#"{"tanghost": {"ip": "10.0.0.1", "tang_url": "http://10.0.0.1", "adv_keys": [], "last_seen": 1700000000}}"#,
+        );
+
+        let store = MemRegistryStore::new();
+        let report = import_from(dir.path(), &store).await.unwrap();
+
+        assert_eq!(report.inserted.machines, 1);
+        assert_eq!(report.inserted.yubikeys, 1);
+        assert_eq!(report.inserted.tang, 1);
+        assert_eq!(report.skipped, RegistryCounts::default());
+        assert!(report.files_missing.is_empty());
+    }
+
+    /// Decision 22 no-clobber law: a pre-existing approved row with a bound TPM EK
+    /// survives an import whose fixture says `status=pending` for the same mac.
+    #[tokio::test]
+    async fn test_import_is_insert_if_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"aa:bb:cc:dd:ee:ff": {"hostname": "h1", "type": "lenovo", "status": "pending", "registered_at": 1700000000}}"#,
+        );
+        write_fixture(dir.path(), YUBIKEY_REGISTRY_FILE, "{}");
+        write_fixture(dir.path(), TANG_REGISTRY_FILE, "{}");
+
+        let store = MemRegistryStore::new();
+        store
+            .insert_machine_if_absent(sample_machine("aa:bb:cc:dd:ee:ff"))
+            .await
+            .unwrap();
+
+        let report = import_from(dir.path(), &store).await.unwrap();
+
+        assert_eq!(report.inserted.machines, 0);
+        assert_eq!(report.skipped.machines, 1);
+        let row = store
+            .get_machine("aa:bb:cc:dd:ee:ff")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.status,
+            MachineStatus::Approved,
+            "no-clobber: pre-existing approved row must survive"
+        );
+        assert_eq!(
+            row.tpm_ek.as_deref(),
+            Some("ek123"),
+            "no-clobber: bound TPM EK must survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_twice_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"aa:bb:cc:dd:ee:ff": {"hostname": "h1", "type": "lenovo", "status": "pending"}}"#,
+        );
+        write_fixture(dir.path(), YUBIKEY_REGISTRY_FILE, "{}");
+        write_fixture(dir.path(), TANG_REGISTRY_FILE, "{}");
+
+        let store = MemRegistryStore::new();
+        let r1 = import_from(dir.path(), &store).await.unwrap();
+        assert_eq!(r1.inserted.machines, 1);
+
+        let r2 = import_from(dir.path(), &store).await.unwrap();
+        assert_eq!(r2.inserted.machines, 0, "second import inserts 0");
+        assert_eq!(r2.skipped.machines, 1);
+    }
+
+    #[tokio::test]
+    async fn test_import_missing_file_warns_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"aa:bb:cc:dd:ee:ff": {"hostname": "h1", "type": "lenovo", "status": "pending"}}"#,
+        );
+        // yubikey-registry.json and tang-registry.json are absent.
+
+        let store = MemRegistryStore::new();
+        let report = import_from(dir.path(), &store).await.unwrap();
+
+        assert_eq!(report.inserted.machines, 1, "the other file still imports");
+        assert_eq!(
+            report.files_missing,
+            vec![
+                YUBIKEY_REGISTRY_FILE.to_string(),
+                TANG_REGISTRY_FILE.to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_malformed_json_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(dir.path(), REGISTRY_FILE, "{ this is not valid json");
+        write_fixture(dir.path(), YUBIKEY_REGISTRY_FILE, "{}");
+        write_fixture(dir.path(), TANG_REGISTRY_FILE, "{}");
+
+        let store = MemRegistryStore::new();
+        let result = import_from(dir.path(), &store).await;
+
+        assert!(result.is_err(), "malformed registry.json must hard-error");
+        assert!(
+            result.unwrap_err().to_string().contains(REGISTRY_FILE),
+            "error must name the offending file"
+        );
+        assert_eq!(
+            store.list_machines().await.unwrap().len(),
+            0,
+            "nothing inserted from the bad file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_normalizes_macs() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"AA-BB-CC-DD-EE-FF": {"hostname": "h1", "type": "lenovo", "status": "pending"}}"#,
+        );
+        write_fixture(dir.path(), YUBIKEY_REGISTRY_FILE, "{}");
+        write_fixture(dir.path(), TANG_REGISTRY_FILE, "{}");
+
+        let store = MemRegistryStore::new();
+        import_from(dir.path(), &store).await.unwrap();
+
+        let row = store.get_machine("aa:bb:cc:dd:ee:ff").await.unwrap();
+        assert!(
+            row.is_some(),
+            "AA-BB-CC-DD-EE-FF must normalize to aa:bb:cc:dd:ee:ff"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_export_python_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemRegistryStore::new();
+        store
+            .insert_machine_if_absent(sample_machine("aa:bb:cc:dd:ee:ff"))
+            .await
+            .unwrap();
+
+        export_to_json(dir.path(), &store).await.unwrap();
+
+        let text = std::fs::read_to_string(dir.path().join(REGISTRY_FILE)).unwrap();
+        let value: Value = serde_json::from_str(&text).unwrap();
+        let obj = value.as_object().expect("dict-keyed export");
+        let entry = obj
+            .get("aa:bb:cc:dd:ee:ff")
+            .and_then(Value::as_object)
+            .expect("keyed by mac");
+
+        assert_eq!(entry["registered_at"], Value::from(1600000000i64));
+        assert_eq!(entry["approved_at"], Value::from(1600000001i64));
+        assert_eq!(entry["tpm_ek"], Value::String("ek123".into()));
+        assert!(
+            !entry.contains_key("last_seen"),
+            "None fields must be omitted, not written as null"
+        );
+        assert!(!entry.contains_key("last_ip"));
+    }
+
+    #[tokio::test]
+    async fn test_export_import_round_trip_inserts_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"aa:bb:cc:dd:ee:ff": {"hostname": "h1", "type": "lenovo", "status": "approved", "registered_at": 1700000000}}"#,
+        );
+        write_fixture(
+            dir.path(),
+            YUBIKEY_REGISTRY_FILE,
+            r#"{"FP1": {"status": "approved", "registered_at": 1700000000}}"#,
+        );
+        write_fixture(
+            dir.path(),
+            TANG_REGISTRY_FILE,
+            r#"{"tanghost": {"ip": "10.0.0.1", "last_seen": 1700000000}}"#,
+        );
+
+        let store = MemRegistryStore::new();
+        let r1 = import_from(dir.path(), &store).await.unwrap();
+        assert_eq!(r1.inserted.machines + r1.inserted.yubikeys + r1.inserted.tang, 3);
+
+        let out_dir = tempfile::tempdir().unwrap();
+        export_to_json(out_dir.path(), &store).await.unwrap();
+
+        let r2 = import_from(out_dir.path(), &store).await.unwrap();
+        assert_eq!(r2.inserted, RegistryCounts::default(), "round-trip inserts 0");
+        assert_eq!(r2.skipped.machines, 1);
+        assert_eq!(r2.skipped.yubikeys, 1);
+        assert_eq!(r2.skipped.tang, 1);
+    }
+
+    /// Anti-over-suppression: a fresh mac (not pre-seeded) really inserts through the
+    /// no-clobber guard, fields intact — the guard doesn't block legitimate new rows.
+    #[tokio::test]
+    async fn test_import_absent_rows_actually_insert() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture(
+            dir.path(),
+            REGISTRY_FILE,
+            r#"{"aa:bb:cc:dd:ee:ff": {"hostname": "fresh-host", "type": "lenovo", "status": "pending", "registered_at": 1700000000, "tpm_ek": "ekabc"}}"#,
+        );
+        write_fixture(dir.path(), YUBIKEY_REGISTRY_FILE, "{}");
+        write_fixture(dir.path(), TANG_REGISTRY_FILE, "{}");
+
+        let store = MemRegistryStore::new();
+        // Pre-seed an unrelated mac so the no-clobber guard is active but must not
+        // block the fresh insert below.
+        store
+            .insert_machine_if_absent(sample_machine("11:22:33:44:55:66"))
+            .await
+            .unwrap();
+
+        let report = import_from(dir.path(), &store).await.unwrap();
+        assert_eq!(
+            report.inserted.machines, 1,
+            "fresh mac must actually insert through the guard"
+        );
+
+        let row = store
+            .get_machine("aa:bb:cc:dd:ee:ff")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.hostname, "fresh-host");
+        assert_eq!(
+            row.tpm_ek.as_deref(),
+            Some("ekabc"),
+            "fields intact on fresh insert"
+        );
+    }
+}

--- a/crates/uaa-control/src/machine_plane/lifecycle.rs
+++ b/crates/uaa-control/src/machine_plane/lifecycle.rs
@@ -1,9 +1,1002 @@
 // file: crates/uaa-control/src/machine_plane/lifecycle.rs
-// version: 1.0.0
+// version: 1.1.1
 // guid: f1273168-f053-480d-8baf-aa653555cb85
 // last-edited: 2026-07-10
 
 //! Machine-plane checkin + install-event ingest (WAL append when degraded).
 //!
-//! STUB — Filled exclusively by install-plane IP-02. Adds `pub fn router()`, then
-//! merges it into `machine_plane::router()` with one line.
+//! Exact parity with `scripts/autoinstall-agent.py` (spec Decision 12) for the
+//! lifecycle POST endpoints: `/api/register`, `/api/checkin`, `/api/webhook`,
+//! `/api/finalreport`, `/api/hardware-info`, `/api/cloud-init`.
+//!
+//! Every response is JSON; invalid request bodies get `400 {"error": "invalid
+//! json"}` (Python `:564-568`). Persistence never talks to CockroachDB directly —
+//! everything goes through the [`Registry`] trait, whose real implementation
+//! ([`FileRegistry`]) is backed by CT-01's snapshot+WAL degraded-mode layer
+//! (`crate::db::store`), so checkin/install-event ingest is fail-OPEN (spec
+//! Decision 4): it always lands in the WAL, never 503s. Unit tests substitute an
+//! in-memory `MockRegistry` — no live CRDB, no network.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde_json::{json, Value};
+
+use crate::db::{
+    store::{read_snapshot, wal_append, write_snapshot, StatePaths},
+    BootTarget, MachineRow, MachineStatus,
+};
+
+/// Default iPXE boot-menu directory (mirrors Python's `IPXE_BOOT_DIR`).
+const IPXE_BOOT_DIR: &str = "/var/www/html/ipxe/boot";
+/// Default directory for webhook-uploaded log files (mirrors Python's `FILES_DIR`).
+const FILES_DIR: &str = "/var/log/cockroach-autoinstall/files";
+
+// ── Pure parity functions ──────────────────────────────────────────────────
+
+/// MAC normalization: lowercase, `-`→`:`, `.`→`:` (Python `normalize_mac`, `:72-73`).
+/// Applied on register AND checkin so `AA-BB-...` and `aa:bb:...` are one machine.
+pub fn normalize_mac(mac: &str) -> String {
+    mac.to_lowercase().replace(['-', '.'], ":")
+}
+
+/// Strip separators for the `mac-<hexmac>.ipxe` filename convention (Python
+/// `mac_to_hex`, `:75-76`).
+fn mac_to_hex(mac: &str) -> String {
+    mac.to_lowercase().replace([':', '-'], "")
+}
+
+/// Exact port of Python's `webhook_should_flip` (`:154-168`).
+///
+/// True only for FINAL successful-install webhook payloads. cloud-init
+/// `reporting.sh` posts status `"finished"`/`"complete"` (always final, the
+/// widened tuple at `:164`). The Rust `uaa` installer posts `event_type:
+/// "status_update"` with status `"running"` (start + per-phase), `"failed"`, and
+/// `"success"` (final at `progress` 100) — a `status_update` may flip only on a
+/// final result: `status == "success"` OR `progress == 100` (accepts a JSON
+/// number, integer or float).
+pub fn webhook_should_flip(data: &Value) -> bool {
+    let status = data.get("status").and_then(Value::as_str).unwrap_or("");
+    let name = data.get("name").and_then(Value::as_str).unwrap_or("");
+    if !name.is_empty() && matches!(status, "finished" | "complete" | "success") {
+        if data.get("event_type").and_then(Value::as_str) == Some("status_update") {
+            let progress_100 = data
+                .get("progress")
+                .and_then(Value::as_f64)
+                .map(|p| p == 100.0)
+                .unwrap_or(false);
+            return status == "success" || progress_100;
+        }
+        return true;
+    }
+    false
+}
+
+/// Exact port of the iPXE flip regex from Python's `flip_ipxe` (`:170-177`):
+/// `re.sub(r"set menu-default \S+", f"set menu-default {target}", content)`.
+pub fn flip_ipxe_content(content: &str, target: &str) -> String {
+    let re = regex::Regex::new(r"set menu-default \S+").expect("static regex is valid");
+    re.replace_all(content, |_: &regex::Captures| format!("set menu-default {target}"))
+        .into_owned()
+}
+
+// ── Registry seam (mockable; no direct DB/process access) ───────────────────
+
+/// Persistence seam for the lifecycle handlers. The real implementation
+/// ([`FileRegistry`]) is backed by CT-01's snapshot+WAL layer; tests substitute an
+/// in-memory mock. Handlers NEVER open a DB connection or spawn a process.
+#[async_trait::async_trait]
+pub trait Registry: Send + Sync {
+    /// Look up a machine row by normalized MAC.
+    async fn get_machine(&self, mac: &str) -> Option<MachineRow>;
+    /// Upsert (full replace) a machine row.
+    async fn upsert_machine(&self, machine: MachineRow);
+    /// Resolve the MAC currently registered under `hostname`, if any (used to
+    /// build the `mac-<hexmac>.ipxe` candidate path, mirroring Python's
+    /// `find_ipxe_file_by_hostname`, `:103-113`).
+    async fn find_mac_by_hostname(&self, hostname: &str) -> Option<String>;
+    /// Append a generic telemetry/log event (webhook / finalreport /
+    /// hardware-info / cloud-init), mirroring Python's `log_event` → `events.jsonl`
+    /// (`received_at` prepended, `:257-259`).
+    async fn append_event(&self, payload: Value);
+    /// Record a final install-history entry (constellation addition; spec CRDB
+    /// schema). Mints a fresh `event_id` UUID AT INGEST — the WAL-replay dedup key
+    /// (Decision 4a) — and returns it. Also updates the machine's `installed_at` +
+    /// `last_install_status`.
+    async fn record_install_event(&self, mac: &str, name: &str, status: &str, finished_at: &str) -> uuid::Uuid;
+}
+
+/// Real [`Registry`]: backed by CT-01's local snapshot (`SnapshotDoc.machines`)
+/// for machine rows and the WAL (`wal_append`) for telemetry/install-history
+/// ingest. Never touches CockroachDB directly (spec Decision 4: telemetry
+/// ingestion is fail-OPEN — a local file append always succeeds barring IO
+/// errors, so this path never 503s).
+pub struct FileRegistry {
+    paths: StatePaths,
+}
+
+impl FileRegistry {
+    pub fn new(paths: StatePaths) -> Self {
+        Self { paths }
+    }
+}
+
+#[async_trait::async_trait]
+impl Registry for FileRegistry {
+    async fn get_machine(&self, mac: &str) -> Option<MachineRow> {
+        let doc = read_snapshot(&self.paths);
+        doc.machines.into_iter().find(|m| m.mac == mac)
+    }
+
+    async fn upsert_machine(&self, machine: MachineRow) {
+        let mut doc = read_snapshot(&self.paths);
+        match doc.machines.iter_mut().find(|m| m.mac == machine.mac) {
+            Some(existing) => *existing = machine,
+            None => doc.machines.push(machine),
+        }
+        if let Err(err) = write_snapshot(&self.paths, &doc) {
+            tracing::error!(%err, "failed to persist machine snapshot");
+        }
+    }
+
+    async fn find_mac_by_hostname(&self, hostname: &str) -> Option<String> {
+        let doc = read_snapshot(&self.paths);
+        doc.machines
+            .into_iter()
+            .find(|m| m.hostname == hostname)
+            .map(|m| m.mac)
+    }
+
+    async fn append_event(&self, payload: Value) {
+        let mut payload = payload;
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("received_at".to_string(), json!(now_epoch_i64()));
+        }
+        if let Err(err) = wal_append(&self.paths, "event", payload) {
+            tracing::error!(%err, "failed to append webhook/log event to WAL");
+        }
+    }
+
+    async fn record_install_event(&self, mac: &str, name: &str, status: &str, finished_at: &str) -> uuid::Uuid {
+        let payload = json!({
+            "mac": mac,
+            "name": name,
+            "status": status,
+            "finished_at": finished_at,
+        });
+        let event_id = match wal_append(&self.paths, "install_history", payload) {
+            Ok(event_id) => event_id,
+            Err(err) => {
+                tracing::error!(%err, "failed to append install_history to WAL");
+                uuid::Uuid::new_v4()
+            }
+        };
+
+        // Best-effort: reflect the final status on the machine row too.
+        let mut doc = read_snapshot(&self.paths);
+        if let Some(row) = doc.machines.iter_mut().find(|m| m.mac == mac) {
+            row.installed_at = Some(finished_at.to_string());
+            row.last_install_status = Some(status.to_string());
+            if let Err(err) = write_snapshot(&self.paths, &doc) {
+                tracing::error!(%err, "failed to persist installed_at/last_install_status");
+            }
+        }
+
+        event_id
+    }
+}
+
+// ── Router / handler wiring ──────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct AppState {
+    registry: Arc<dyn Registry>,
+    ipxe_dir: Arc<PathBuf>,
+    files_dir: Arc<PathBuf>,
+}
+
+fn default_state() -> AppState {
+    AppState {
+        registry: Arc::new(FileRegistry::new(StatePaths::default())),
+        ipxe_dir: Arc::new(PathBuf::from(IPXE_BOOT_DIR)),
+        files_dir: Arc::new(PathBuf::from(FILES_DIR)),
+    }
+}
+
+/// The lifecycle sub-router. Merged into `machine_plane::router()` by the
+/// coordinator with `.merge(lifecycle::router())` (one line, owned by CT-01's
+/// `mod.rs` — never edited here). Standalone-testable: building this router
+/// touches no filesystem/network state (all IO is deferred to request time).
+pub fn router() -> Router {
+    build_router(default_state())
+}
+
+fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/register", post(handle_register))
+        .route("/api/checkin", post(handle_checkin))
+        .route("/api/webhook", post(handle_webhook))
+        .route("/api/finalreport", post(handle_finalreport))
+        .route("/api/hardware-info", post(handle_hardware_info))
+        .route("/api/cloud-init", post(handle_cloud_init))
+        .with_state(state)
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────
+
+fn json_response(code: StatusCode, body: Value) -> Response {
+    (code, Json(body)).into_response()
+}
+
+/// Parse the raw request body as JSON, or short-circuit with the Python-parity
+/// `400 {"error": "invalid json"}` response (`:564-568`).
+#[allow(clippy::result_large_err)]
+fn parse_json(body: &Bytes) -> Result<Value, Response> {
+    serde_json::from_slice(body)
+        .map_err(|_| json_response(StatusCode::BAD_REQUEST, json!({"error": "invalid json"})))
+}
+
+fn now_epoch_i64() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn now_epoch_string() -> String {
+    now_epoch_i64().to_string()
+}
+
+// ── /api/register (Python `:571-596`) ────────────────────────────────────────
+
+async fn handle_register(State(state): State<AppState>, body: Bytes) -> Response {
+    let data = match parse_json(&body) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    let mac = normalize_mac(data.get("mac").and_then(Value::as_str).unwrap_or(""));
+    let hostname = data
+        .get("hostname")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let ip = data
+        .get("ip")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let server_type = data
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("lenovo")
+        .to_string();
+
+    if mac.is_empty() || hostname.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            json!({"ok": false, "error": "mac and hostname required"}),
+        );
+    }
+
+    let existing = state.registry.get_machine(&mac).await;
+
+    // PRESERVE status/registered_at/tpm_ek (default pending/now/null); OVERWRITE
+    // hostname/ip/type. Everything else carries forward unchanged (Python's model
+    // has no other fields to preserve or reset).
+    let status = existing
+        .as_ref()
+        .map(|m| m.status.clone())
+        .unwrap_or(MachineStatus::Pending);
+    let registered_at = existing
+        .as_ref()
+        .and_then(|m| m.registered_at.clone())
+        .unwrap_or_else(now_epoch_string);
+    let tpm_ek = existing.as_ref().and_then(|m| m.tpm_ek.clone());
+    let boot_target = existing
+        .as_ref()
+        .map(|m| m.boot_target.clone())
+        .unwrap_or(BootTarget::LocalDisk);
+    let approved_at = existing.as_ref().and_then(|m| m.approved_at.clone());
+    let last_seen = existing.as_ref().and_then(|m| m.last_seen.clone());
+    let last_ip = existing.as_ref().and_then(|m| m.last_ip.clone());
+    let installed_at = existing.as_ref().and_then(|m| m.installed_at.clone());
+    let last_install_status = existing.as_ref().and_then(|m| m.last_install_status.clone());
+
+    let row = MachineRow {
+        mac: mac.clone(),
+        hostname,
+        ip: Some(ip),
+        r#type: server_type,
+        status: status.clone(),
+        boot_target,
+        tpm_ek,
+        registered_at: Some(registered_at),
+        approved_at,
+        last_seen,
+        last_ip,
+        installed_at,
+        last_install_status,
+        updated_at: Some(now_epoch_string()),
+    };
+    state.registry.upsert_machine(row).await;
+
+    let status_str: String = status.into();
+    tracing::info!(%mac, %status_str, "REGISTER");
+    json_response(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "status": status_str,
+            "message": format!(
+                "Registered. Approve with: curl http://172.16.2.30:25000/api/approve/{mac}"
+            ),
+        }),
+    )
+}
+
+// ── /api/checkin (Python `:599-621`) ─────────────────────────────────────────
+
+async fn handle_checkin(State(state): State<AppState>, body: Bytes) -> Response {
+    let data = match parse_json(&body) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    let mac = normalize_mac(data.get("mac").and_then(Value::as_str).unwrap_or(""));
+    let tpm_ek = data
+        .get("tpm_ek")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let ip = data
+        .get("ip")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let mut entry = match state.registry.get_machine(&mac).await {
+        Some(e) => e,
+        None => {
+            tracing::info!(%mac, "CHECKIN DENIED - not registered");
+            return json_response(
+                StatusCode::FORBIDDEN,
+                json!({"ok": false, "error": "Not registered"}),
+            );
+        }
+    };
+
+    // Order matches Python exactly: lookup -> unknown 403 (above) -> first-bind
+    // -> mismatch-403 (return BEFORE touching last_seen, and WITHOUT persisting)
+    // -> update last_seen/last_ip -> 200.
+    let existing_ek_is_set = entry
+        .tpm_ek
+        .as_deref()
+        .map(|ek| !ek.is_empty())
+        .unwrap_or(false);
+    if !tpm_ek.is_empty() {
+        if !existing_ek_is_set {
+            entry.tpm_ek = Some(tpm_ek.clone());
+            tracing::info!(%mac, "CHECKIN TPM bound");
+        } else if entry.tpm_ek.as_deref() != Some(tpm_ek.as_str()) {
+            tracing::warn!(%mac, "CHECKIN TPM MISMATCH");
+            return json_response(
+                StatusCode::FORBIDDEN,
+                json!({"ok": false, "error": "TPM mismatch - MAC may be spoofed"}),
+            );
+        }
+    }
+
+    entry.last_seen = Some(now_epoch_string());
+    entry.last_ip = Some(ip);
+    entry.updated_at = Some(now_epoch_string());
+    let status_str: String = entry.status.clone().into();
+    let approved = matches!(entry.status, MachineStatus::Approved);
+    state.registry.upsert_machine(entry).await;
+
+    tracing::info!(%mac, %status_str, "CHECKIN");
+    json_response(
+        StatusCode::OK,
+        json!({"ok": true, "status": status_str, "approved": approved}),
+    )
+}
+
+// ── /api/webhook (Python `:624-650`) ─────────────────────────────────────────
+
+async fn handle_webhook(State(state): State<AppState>, body: Bytes) -> Response {
+    let data = match parse_json(&body) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    // (a) Append the event FIRST, before any flip attempt (Python order).
+    state.registry.append_event(data.clone()).await;
+
+    let status = data
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let name = data
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    if webhook_should_flip(&data) {
+        // (b) A missing iPXE file (USB-only host) or ANY flip error is logged and
+        // SWALLOWED — the webhook itself still succeeds (`:633-635`).
+        let (ok, msg) = flip_ipxe(state.registry.as_ref(), &state.ipxe_dir, &name).await;
+        tracing::info!(%name, %status, flip_ok = ok, %msg, "WEBHOOK auto-flip");
+
+        // (c) Record install_history regardless of flip outcome (final success is
+        // final success even if the iPXE file could not be located).
+        let mac = state
+            .registry
+            .find_mac_by_hostname(&name)
+            .await
+            .unwrap_or_default();
+        let finished_at = now_epoch_string();
+        let event_id = state
+            .registry
+            .record_install_event(&mac, &name, &status, &finished_at)
+            .await;
+        tracing::info!(%event_id, %mac, %name, "install_history recorded");
+    } else {
+        tracing::info!(
+            %name,
+            event_type = ?data.get("event_type"),
+            %status,
+            "WEBHOOK (no flip)"
+        );
+    }
+
+    // (d) decode files[] to the CT-01 files dir; per-file failures are swallowed.
+    if let Some(files) = data.get("files").and_then(Value::as_array) {
+        for f in files {
+            save_webhook_file(&state.files_dir, &name, f);
+        }
+    }
+
+    json_response(StatusCode::OK, json!({"ok": true}))
+}
+
+fn save_webhook_file(files_dir: &std::path::Path, hostname: &str, f: &Value) {
+    let raw_path = f.get("path").and_then(Value::as_str).unwrap_or("unknown");
+    let sanitized = raw_path.replace('/', "_");
+    let ts = now_epoch_string();
+    let hostname = if hostname.is_empty() { "unknown" } else { hostname };
+    let out = files_dir.join(format!("{hostname}-{ts}-{sanitized}"));
+    let content_b64 = f.get("content").and_then(Value::as_str).unwrap_or("");
+
+    use base64::Engine;
+    match base64::engine::general_purpose::STANDARD.decode(content_b64) {
+        Ok(bytes) => {
+            if let Some(parent) = out.parent() {
+                if let Err(err) = std::fs::create_dir_all(parent) {
+                    tracing::warn!(%err, path = %parent.display(), "failed to create files dir");
+                    return;
+                }
+            }
+            match std::fs::write(&out, bytes) {
+                Ok(()) => tracing::info!(path = %out.display(), "Saved log"),
+                Err(err) => tracing::warn!(%err, path = %out.display(), "Failed to save log"),
+            }
+        }
+        Err(err) => tracing::warn!(%err, %raw_path, "Failed to decode webhook file content"),
+    }
+}
+
+/// Exact port of Python's `flip_ipxe` (`:170-177`): resolve the target file by
+/// hostname, then rewrite `set menu-default \S+` to the given target. A missing
+/// file (or any IO error) returns `(false, "No iPXE file found for {hostname}")`
+/// / a swallowed error message — never propagated.
+async fn flip_ipxe(registry: &dyn Registry, ipxe_dir: &std::path::Path, hostname: &str) -> (bool, String) {
+    let path = match resolve_ipxe_path(registry, ipxe_dir, hostname).await {
+        Some(p) if p.exists() => p,
+        _ => return (false, format!("No iPXE file found for {hostname}")),
+    };
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(err) => return (false, format!("flip failed: {err}")),
+    };
+    let new_content = flip_ipxe_content(&content, "boot-local-disk");
+    match std::fs::write(&path, new_content) {
+        Ok(()) => (true, format!("Flipped {hostname} to boot-local-disk")),
+        Err(err) => (false, format!("flip failed: {err}")),
+    }
+}
+
+/// Exact port of Python's `find_ipxe_file_by_hostname` (`:103-113`): registry
+/// hostname match first (candidate path is NOT required to exist yet — existence
+/// is checked by the caller), then a fallback scan of `*.ipxe` files for a
+/// `set hostname <name>` content match.
+async fn resolve_ipxe_path(
+    registry: &dyn Registry,
+    ipxe_dir: &std::path::Path,
+    hostname: &str,
+) -> Option<PathBuf> {
+    if let Some(mac) = registry.find_mac_by_hostname(hostname).await {
+        return Some(ipxe_dir.join(format!("mac-{}.ipxe", mac_to_hex(&mac))));
+    }
+    let entries = std::fs::read_dir(ipxe_dir).ok()?;
+    let needle = format!("set hostname {hostname}");
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.extension().and_then(|e| e.to_str()) == Some("ipxe") {
+            if let Ok(content) = std::fs::read_to_string(&p) {
+                if content.contains(&needle) {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ── /api/finalreport, /api/hardware-info, /api/cloud-init (Python `:652-656`) ─
+
+async fn handle_finalreport(State(state): State<AppState>, body: Bytes) -> Response {
+    handle_log_only(state, "/api/finalreport", body).await
+}
+
+async fn handle_hardware_info(State(state): State<AppState>, body: Bytes) -> Response {
+    handle_log_only(state, "/api/hardware-info", body).await
+}
+
+async fn handle_cloud_init(State(state): State<AppState>, body: Bytes) -> Response {
+    handle_log_only(state, "/api/cloud-init", body).await
+}
+
+/// Shared handler for the three log-only sinks: `log_event({"endpoint": path,
+/// **data})`, reply `200 {"ok":true}` (Python `:652-656`, event shape `:653`).
+async fn handle_log_only(state: AppState, endpoint: &str, body: Bytes) -> Response {
+    let data = match parse_json(&body) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    let mut payload = json!({"endpoint": endpoint});
+    if let (Some(obj), Some(data_obj)) = (payload.as_object_mut(), data.as_object()) {
+        for (k, v) in data_obj {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    state.registry.append_event(payload).await;
+
+    tracing::info!(%endpoint, "log-only event");
+    json_response(StatusCode::OK, json!({"ok": true}))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    #[derive(Debug, Clone)]
+    struct RecordedInstallEvent {
+        event_id: uuid::Uuid,
+        mac: String,
+        #[allow(dead_code)]
+        name: String,
+        #[allow(dead_code)]
+        status: String,
+        #[allow(dead_code)]
+        finished_at: String,
+    }
+
+    /// In-memory mock — zero filesystem, zero CRDB.
+    #[derive(Default)]
+    struct MockRegistry {
+        machines: Mutex<HashMap<String, MachineRow>>,
+        events: Mutex<Vec<Value>>,
+        install_events: Mutex<Vec<RecordedInstallEvent>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Registry for MockRegistry {
+        async fn get_machine(&self, mac: &str) -> Option<MachineRow> {
+            self.machines.lock().unwrap().get(mac).cloned()
+        }
+        async fn upsert_machine(&self, machine: MachineRow) {
+            self.machines
+                .lock()
+                .unwrap()
+                .insert(machine.mac.clone(), machine);
+        }
+        async fn find_mac_by_hostname(&self, hostname: &str) -> Option<String> {
+            self.machines
+                .lock()
+                .unwrap()
+                .values()
+                .find(|m| m.hostname == hostname)
+                .map(|m| m.mac.clone())
+        }
+        async fn append_event(&self, payload: Value) {
+            self.events.lock().unwrap().push(payload);
+        }
+        async fn record_install_event(
+            &self,
+            mac: &str,
+            name: &str,
+            status: &str,
+            finished_at: &str,
+        ) -> uuid::Uuid {
+            let event_id = uuid::Uuid::new_v4();
+            self.install_events.lock().unwrap().push(RecordedInstallEvent {
+                event_id,
+                mac: mac.to_string(),
+                name: name.to_string(),
+                status: status.to_string(),
+                finished_at: finished_at.to_string(),
+            });
+            // Mirror FileRegistry's side effect so tests can assert on it too.
+            if let Some(row) = self.machines.lock().unwrap().get_mut(mac) {
+                row.installed_at = Some(finished_at.to_string());
+                row.last_install_status = Some(status.to_string());
+            }
+            event_id
+        }
+    }
+
+    fn base_machine(mac: &str, hostname: &str) -> MachineRow {
+        MachineRow {
+            mac: mac.to_string(),
+            hostname: hostname.to_string(),
+            ip: Some("10.0.0.1".to_string()),
+            r#type: "lenovo".to_string(),
+            status: MachineStatus::Pending,
+            boot_target: BootTarget::LocalDisk,
+            tpm_ek: None,
+            registered_at: Some("1000".to_string()),
+            approved_at: None,
+            last_seen: None,
+            last_ip: None,
+            installed_at: None,
+            last_install_status: None,
+            updated_at: None,
+        }
+    }
+
+    fn test_state_with(registry: Arc<dyn Registry>, ipxe_dir: PathBuf) -> AppState {
+        AppState {
+            registry,
+            ipxe_dir: Arc::new(ipxe_dir.clone()),
+            files_dir: Arc::new(ipxe_dir),
+        }
+    }
+
+    async fn body_json(resp: Response) -> Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // ── pure function tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_normalize_mac() {
+        assert_eq!(normalize_mac("AA-BB-CC-DD-EE-FF"), "aa:bb:cc:dd:ee:ff");
+        assert_eq!(normalize_mac("aa.bb.cc.dd.ee.ff"), "aa:bb:cc:dd:ee:ff");
+        assert_eq!(normalize_mac("aa:bb:cc:dd:ee:ff"), "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn test_flip_ipxe_content_replaces_menu_default() {
+        let content = "#!ipxe\nset menu-default pxe-install\nboot\n";
+        let out = flip_ipxe_content(content, "boot-local-disk");
+        assert_eq!(out, "#!ipxe\nset menu-default boot-local-disk\nboot\n");
+    }
+
+    #[test]
+    fn test_flip_predicate_matrix() {
+        let cases: Vec<(Value, bool)> = vec![
+            (json!({"name": "h1", "status": "finished"}), true),
+            (json!({"name": "h1", "status": "complete"}), true),
+            (
+                json!({"name": "h1", "status": "success", "event_type": "status_update"}),
+                true,
+            ),
+            (
+                json!({"name": "h1", "status": "running", "event_type": "status_update", "progress": 50}),
+                false,
+            ),
+            (
+                json!({"name": "h1", "status": "finished", "event_type": "status_update", "progress": 100}),
+                true,
+            ),
+            (json!({"name": "h1", "status": "failed"}), false),
+            (json!({"name": "", "status": "success"}), false),
+        ];
+        for (data, expected) in cases {
+            assert_eq!(
+                webhook_should_flip(&data),
+                expected,
+                "predicate mismatch for payload: {data}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_router_builds_standalone() {
+        // Constructing the router touches no filesystem/network — only requests do.
+        let _ = router();
+    }
+
+    // ── /api/register ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_register_preserves_approval_and_ek() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let mut seed = base_machine("aa:bb:cc:dd:ee:ff", "old-host");
+        seed.status = MachineStatus::Approved;
+        seed.tpm_ek = Some("ek-123".to_string());
+        registry.upsert_machine(seed).await;
+
+        let state = test_state_with(registry.clone(), dir.path().to_path_buf());
+        let body = Bytes::from(
+            serde_json::to_vec(&json!({
+                "mac": "AA-BB-CC-DD-EE-FF",
+                "hostname": "new-host",
+                "ip": "10.0.0.2"
+            }))
+            .unwrap(),
+        );
+        let resp = handle_register(State(state), body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["status"], "approved");
+
+        let updated = registry.get_machine("aa:bb:cc:dd:ee:ff").await.unwrap();
+        assert_eq!(updated.status, MachineStatus::Approved, "approval preserved");
+        assert_eq!(updated.tpm_ek.as_deref(), Some("ek-123"), "EK preserved");
+        assert_eq!(updated.hostname, "new-host", "hostname overwritten");
+        assert_eq!(updated.registered_at.as_deref(), Some("1000"), "registered_at preserved");
+    }
+
+    #[tokio::test]
+    async fn test_register_missing_fields_400() {
+        let dir = tempdir().unwrap();
+        let state = test_state_with(Arc::new(MockRegistry::default()), dir.path().to_path_buf());
+        let body = Bytes::from(serde_json::to_vec(&json!({"hostname": "h1"})).unwrap());
+        let resp = handle_register(State(state), body).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"], "mac and hostname required");
+    }
+
+    // ── /api/checkin ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_checkin_first_bind_then_mismatch_403() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry
+            .upsert_machine(base_machine("aa:bb:cc:dd:ee:ff", "h1"))
+            .await;
+        let state = test_state_with(registry.clone(), dir.path().to_path_buf());
+
+        // First checkin binds the EK.
+        let body1 = Bytes::from(
+            serde_json::to_vec(&json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-1", "ip": "10.0.0.5"}))
+                .unwrap(),
+        );
+        let resp1 = handle_checkin(State(state.clone()), body1).await;
+        assert_eq!(resp1.status(), StatusCode::OK);
+        let bound = registry.get_machine("aa:bb:cc:dd:ee:ff").await.unwrap();
+        assert_eq!(bound.tpm_ek.as_deref(), Some("ek-1"));
+
+        // Force a distinguishable last_seen sentinel so the "unchanged" assertion
+        // below cannot pass by same-second timing coincidence.
+        let mut sentinel = bound.clone();
+        sentinel.last_seen = Some("sentinel-42".to_string());
+        registry.upsert_machine(sentinel).await;
+
+        // Second checkin with a DIFFERENT EK -> 403, last_seen untouched.
+        let body2 = Bytes::from(
+            serde_json::to_vec(&json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-2", "ip": "10.0.0.6"}))
+                .unwrap(),
+        );
+        let resp2 = handle_checkin(State(state.clone()), body2).await;
+        assert_eq!(resp2.status(), StatusCode::FORBIDDEN);
+        let v = body_json(resp2).await;
+        assert_eq!(v["error"], "TPM mismatch - MAC may be spoofed");
+
+        let after_mismatch = registry.get_machine("aa:bb:cc:dd:ee:ff").await.unwrap();
+        assert_eq!(
+            after_mismatch.last_seen.as_deref(),
+            Some("sentinel-42"),
+            "last_seen must be unchanged on TPM mismatch"
+        );
+        assert_eq!(
+            after_mismatch.tpm_ek.as_deref(),
+            Some("ek-1"),
+            "bound EK must not be overwritten by the mismatching attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_checkin_matching_ek_ok() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let mut m = base_machine("aa:bb:cc:dd:ee:ff", "h1");
+        m.status = MachineStatus::Approved;
+        m.tpm_ek = Some("ek-1".to_string());
+        m.last_seen = Some("sentinel-old".to_string());
+        registry.upsert_machine(m).await;
+        let state = test_state_with(registry.clone(), dir.path().to_path_buf());
+
+        let body = Bytes::from(
+            serde_json::to_vec(&json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-1", "ip": "10.0.0.9"}))
+                .unwrap(),
+        );
+        let resp = handle_checkin(State(state), body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["approved"], true);
+
+        let updated = registry.get_machine("aa:bb:cc:dd:ee:ff").await.unwrap();
+        assert_ne!(
+            updated.last_seen.as_deref(),
+            Some("sentinel-old"),
+            "legitimate checkin must update last_seen"
+        );
+        assert_eq!(updated.last_ip.as_deref(), Some("10.0.0.9"));
+        assert_eq!(updated.tpm_ek.as_deref(), Some("ek-1"), "EK unchanged on match");
+    }
+
+    // ── /api/webhook ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_webhook_missing_ipxe_swallowed() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        // No machine registered under this hostname; no iPXE files on disk.
+        let state = test_state_with(registry.clone(), dir.path().to_path_buf());
+
+        let body = Bytes::from(
+            serde_json::to_vec(&json!({
+                "name": "h-missing",
+                "status": "success",
+                "event_type": "status_update",
+                "progress": 100
+            }))
+            .unwrap(),
+        );
+        let resp = handle_webhook(State(state), body).await;
+        assert_eq!(resp.status(), StatusCode::OK, "flip failure must be swallowed");
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+
+        assert_eq!(
+            registry.install_events.lock().unwrap().len(),
+            1,
+            "install_history still recorded despite missing iPXE file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_webhook_flip_and_history() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry
+            .upsert_machine(base_machine("aa:bb:cc:dd:ee:ff", "h-present"))
+            .await;
+
+        let ipxe_path = dir.path().join("mac-aabbccddeeff.ipxe");
+        std::fs::write(&ipxe_path, "#!ipxe\nset menu-default pxe-install\nboot\n").unwrap();
+
+        let state = test_state_with(registry.clone(), dir.path().to_path_buf());
+        let body = Bytes::from(
+            serde_json::to_vec(&json!({
+                "name": "h-present",
+                "status": "success",
+                "event_type": "status_update",
+                "progress": 100
+            }))
+            .unwrap(),
+        );
+        let resp = handle_webhook(State(state), body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let content = std::fs::read_to_string(&ipxe_path).unwrap();
+        assert!(
+            content.contains("set menu-default boot-local-disk"),
+            "iPXE file must be flipped: {content}"
+        );
+
+        let events = registry.install_events.lock().unwrap();
+        assert_eq!(events.len(), 1, "exactly one install_history record");
+        assert_ne!(events[0].event_id, uuid::Uuid::nil(), "event_id must be a minted UUID");
+        assert_eq!(events[0].mac, "aa:bb:cc:dd:ee:ff");
+    }
+
+    // ── invalid JSON (shared parity across all endpoints) ────────────────
+
+    #[tokio::test]
+    async fn test_invalid_json_400() {
+        let dir = tempdir().unwrap();
+        let state = test_state_with(Arc::new(MockRegistry::default()), dir.path().to_path_buf());
+
+        let resp = handle_register(State(state.clone()), Bytes::from_static(b"not json")).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "invalid json");
+
+        let resp2 = handle_checkin(State(state.clone()), Bytes::from_static(b"{bad")).await;
+        assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+
+        let resp3 = handle_webhook(State(state), Bytes::from_static(b"[1,2")).await;
+        assert_eq!(resp3.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // ── log-only sinks ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_log_only_sinks_ok_and_tag_endpoint() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let state = test_state_with(registry.clone(), dir.path().to_path_buf());
+
+        for (path, resp) in [
+            (
+                "/api/finalreport",
+                handle_finalreport(
+                    State(state.clone()),
+                    Bytes::from(serde_json::to_vec(&json!({"client_id": "c1"})).unwrap()),
+                )
+                .await,
+            ),
+            (
+                "/api/hardware-info",
+                handle_hardware_info(
+                    State(state.clone()),
+                    Bytes::from(serde_json::to_vec(&json!({"cpu": "x86"})).unwrap()),
+                )
+                .await,
+            ),
+            (
+                "/api/cloud-init",
+                handle_cloud_init(
+                    State(state.clone()),
+                    Bytes::from(serde_json::to_vec(&json!({"stage": "final"})).unwrap()),
+                )
+                .await,
+            ),
+        ] {
+            assert_eq!(resp.status(), StatusCode::OK, "{path}");
+            let v = body_json(resp).await;
+            assert_eq!(v["ok"], true, "{path}");
+        }
+
+        let events = registry.events.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        let endpoints: Vec<&str> = events
+            .iter()
+            .map(|e| e["endpoint"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            endpoints,
+            vec!["/api/finalreport", "/api/hardware-info", "/api/cloud-init"]
+        );
+    }
+}

--- a/crates/uaa-control/src/machine_plane/mod.rs
+++ b/crates/uaa-control/src/machine_plane/mod.rs
@@ -1,5 +1,5 @@
 // file: crates/uaa-control/src/machine_plane/mod.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: eee7b5c0-24d0-4406-b5f6-68d5bac52cae
 // last-edited: 2026-07-10
 
@@ -24,12 +24,13 @@ use serde_json::json;
 
 /// The `:25000` router. Followers merge their submodule routers here (see module doc).
 pub fn router() -> Router {
-    Router::new().route(
-        "/healthz",
-        get(|| async { Json(json!({ "service": "uaa-control", "listener": "machine-plane" })) }),
-    )
-    // IP-01: .merge(seeds::router())
-    // IP-02: .merge(lifecycle::router())
+    Router::new()
+        .route(
+            "/healthz",
+            get(|| async { Json(json!({ "service": "uaa-control", "listener": "machine-plane" })) }),
+        )
+    // IP-01: .merge(seeds::router()) [reverted — handler trait bound; re-dispatch]
+        .merge(lifecycle::router()) // IP-02
     // IP-03: .merge(inventory::router())
     // IP-04: .merge(dashboard::router())
 }

--- a/crates/uaa-control/src/reinstall.rs
+++ b/crates/uaa-control/src/reinstall.rs
@@ -1,8 +1,1173 @@
 // file: crates/uaa-control/src/reinstall.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 27c0208b-9b94-40e4-b60b-27732d25e471
 // last-edited: 2026-07-10
 
-//! One-click reinstall flow + boot-target reconciliation.
+//! One-click reinstall flow + boot-target reconciliation (spec C3 / Decision 13).
 //!
-//! STUB — Filled exclusively by control TASK-06 (CT-06).
+//! `boot_target` on the `machines` registry row is the ONE authoritative field.
+//! [`reinstall_machine`] sets it to `custom-autoinstall`, projects that value to
+//! BOTH the uaa-web iPXE flip layer and the uaa-pxe dnsmasq layer, power-cycles
+//! the host (off then on — reset/cycle are unrepresentable, Decision 15), then
+//! watches install events for a bounded window. A host must never be left
+//! half-projected: if either layer fails to reconcile, both are flipped back to
+//! `local-disk` best-effort and the registry field is restored. If the bounded
+//! watch times out (or the install itself reports failure), the same fail-safe
+//! flip-back runs and a loud `tracing::error!` alert is emitted. A cooldown
+//! window refuses an un-confirmed re-trigger shortly after a prior attempt.
+//!
+//! Hard refusals (fail-closed, BEFORE any side effect): the `FleetConfig`
+//! reinstall deny-list (`unimatrixone`) and any host whose registry approval
+//! status is not `approved`.
+//!
+//! # Coordinator wiring (read before touching any other file)
+//!
+//! This module is purely additive and self-contained. It does NOT import from
+//! `saga.rs` (CT-05) or `db::registry` (CT-02) because both were still
+//! header-only stubs at authoring time (wave-4 gate: only CT-01 + core-proto
+//! CP-03 were merged). Per the coordinator wiring rule this module declares its
+//! own narrow local traits instead of blocking:
+//!
+//! - [`WebClient`] / [`PxeClient`] — TODO(coordinator): once CT-05's `saga.rs`
+//!   lands its own `WebClient`/`PxeClient` traits, unify these two
+//!   declarations (either re-export one from the other, or hoist a shared
+//!   definition into `db::mod` / a new `clients` module). Until then the two
+//!   declarations are structurally identical and safe to keep separate.
+//! - [`ReinstallRegistry`] — a narrow registry seam (get/set boot_target,
+//!   approval status, cooldown timestamp) standing in for CT-02's `db::registry`
+//!   `RegistryStore`. TODO(coordinator): once CT-02 lands, wire a
+//!   `RegistryStore`-backed impl of `ReinstallRegistry` (construction only).
+//!
+//! [`PowerControl`] wraps `uaa_core::power::run_power_action` — the mock impl
+//! used by every test never touches SSH or a real executor; [`RuntimePowerControl`]
+//! is the only impl that does, and it is pure construction/delegation (no IPMI
+//! logic lives here — see `uaa-core/src/power/mod.rs`).
+
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+
+use uaa_core::fleet::FleetConfig;
+
+// ── Local narrow traits (seams) ─────────────────────────────────────────────
+
+/// uaa-web iPXE boot-target flip client. Local stand-in for CT-05's trait of
+/// the same shape — see the module-level coordinator-wiring note.
+#[async_trait]
+pub trait WebClient {
+    /// Flip the iPXE boot target for `mac` to `target` (a `BootTarget` wire
+    /// string: `"custom-autoinstall"` or `"local-disk"`).
+    async fn flip_boot_target(&self, mac: &str, target: &str) -> anyhow::Result<()>;
+}
+
+/// uaa-pxe dnsmasq boot-target client. Local stand-in for CT-05's trait of the
+/// same shape — see the module-level coordinator-wiring note.
+#[async_trait]
+pub trait PxeClient {
+    /// Set the dnsmasq/PXE boot target for `mac` to `target` (same wire
+    /// strings as [`WebClient::flip_boot_target`]).
+    async fn set_boot_target(&self, mac: &str, target: &str) -> anyhow::Result<()>;
+}
+
+/// Remote power control, keyed by hostname. Wraps
+/// `uaa_core::power::run_power_action` (Decision 15: ipmitool always runs via
+/// `ssh 172.16.2.30`, never locally). Only `off`/`on` are representable —
+/// `chassis power reset`/`cycle` are unreliable on the X10DSC+ and stay
+/// unrepresentable at every layer, including this one.
+///
+/// `?Send`: `run_power_action` takes `&mut dyn CommandExecutor`, a trait that
+/// does not itself require `Send`, so [`RuntimePowerControl`]'s futures are
+/// not `Send`. This module never spawns a task across threads, so opting out
+/// of async-trait's default `Send` bound is the correct (and only) fix
+/// available without touching `uaa-core` (out of scope for this file).
+#[async_trait(?Send)]
+pub trait PowerControl {
+    /// Power the host off.
+    async fn off(&self, host: &str) -> anyhow::Result<()>;
+    /// Power the host on.
+    async fn on(&self, host: &str) -> anyhow::Result<()>;
+}
+
+/// Install-event status as reported by the installer's checkin/webhook path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallStatus {
+    /// The install completed successfully.
+    Success,
+    /// The install reported a failure.
+    Failed,
+    /// The install is still running (or no event has arrived yet).
+    InProgress,
+}
+
+/// Narrow seam over the install-event source polled by the bounded watch.
+#[async_trait]
+pub trait InstallWatch {
+    /// Latest known install status for `mac`, or `None` if no event has been
+    /// recorded yet.
+    async fn latest_status(&self, mac: &str) -> anyhow::Result<Option<InstallStatus>>;
+}
+
+/// Registry seam: everything [`reinstall_machine`] needs to read/write on the
+/// `machines` row, without depending on CT-02's not-yet-merged `db::registry`.
+#[async_trait]
+pub trait ReinstallRegistry {
+    /// Look up the machine's hostname, approval, current `boot_target`, and
+    /// cooldown timestamp. `None` means the mac is not registered at all —
+    /// treated identically to `NotApproved` (fail-closed; there is no
+    /// approval status to check).
+    async fn get_machine(&self, mac: &str) -> anyhow::Result<Option<RegistryMachine>>;
+    /// Persist a new `boot_target` for `mac` (used both for the forward write
+    /// and for restore-on-failure / fail-safe flip-back).
+    async fn set_boot_target(&self, mac: &str, target: &str) -> anyhow::Result<()>;
+    /// Stamp the cooldown timestamp for `mac`.
+    async fn stamp_reinstall(&self, mac: &str, at: SystemTime) -> anyhow::Result<()>;
+}
+
+/// The subset of a `machines` row [`ReinstallRegistry::get_machine`] needs to
+/// return. Deliberately NOT `db::MachineRow` (owned by CT-01; this seam is
+/// independent of that schema until CT-02 lands — see coordinator-wiring note).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegistryMachine {
+    pub hostname: String,
+    pub approved: bool,
+    pub boot_target: String,
+    pub last_reinstall_at: Option<SystemTime>,
+}
+
+/// Injectable clock: `now()` for cooldown/timeout comparisons, `sleep()` for
+/// the watch poll interval. The real impl sleeps for real; the test impl
+/// advances a virtual clock instantly so tests never wait on a real timer.
+#[async_trait]
+pub trait Clock {
+    /// Current time.
+    fn now(&self) -> SystemTime;
+    /// Wait `dur` before the next watch poll.
+    async fn sleep(&self, dur: Duration);
+}
+
+/// Real-time [`Clock`] impl used outside tests.
+pub struct SystemClock;
+
+#[async_trait]
+impl Clock for SystemClock {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+
+    async fn sleep(&self, dur: Duration) {
+        tokio::time::sleep(dur).await;
+    }
+}
+
+// ── Request/outcome/refusal types ───────────────────────────────────────────
+
+/// A one-click reinstall request.
+#[derive(Debug, Clone)]
+pub struct ReinstallRequest {
+    pub mac: String,
+    /// Must be `true` to bypass an active cooldown window.
+    pub confirm: bool,
+}
+
+/// Result of a [`reinstall_machine`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReinstallOutcome {
+    /// The install reported success.
+    Done,
+    /// The bounded watch timed out, or the install reported failure; a
+    /// fail-safe flip-back to `local-disk` on both layers (+ registry) was
+    /// attempted. `flip_back_ok` is `false` if any leg of that flip-back
+    /// itself failed (never swallowed — also `tracing::error!`-logged).
+    TimedOutFlippedBack { flip_back_ok: bool },
+    /// A guard refused the request before any side effect.
+    Refused(RefusalReason),
+}
+
+/// Why a reinstall request was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefusalReason {
+    /// The host is on the `FleetConfig` reinstall deny-list (e.g. `unimatrixone`).
+    DenyListed,
+    /// The mac is unregistered, or its registry status is not `approved`.
+    NotApproved,
+    /// A prior reinstall attempt is within the cooldown window and the
+    /// request did not set `confirm: true`. Names the remaining window.
+    CooldownActive { remaining_min: u64 },
+    /// The dual-layer projection could not be reconciled; both layers (and
+    /// the registry) were flipped/restored best-effort. Names the underlying
+    /// web/pxe errors.
+    Unreconciled(String),
+}
+
+/// Timing configuration for [`reinstall_machine`].
+#[derive(Debug, Clone)]
+pub struct ReinstallConfig {
+    /// How long the watch polls before declaring a timeout (default 45 min).
+    pub watch_timeout: Duration,
+    /// Delay between watch polls (default 30 s).
+    pub poll_interval: Duration,
+    /// Cooldown window after an attempt reaches the power step before a
+    /// re-trigger requires `confirm: true` (default 30 min).
+    pub cooldown: Duration,
+}
+
+impl Default for ReinstallConfig {
+    fn default() -> Self {
+        Self {
+            watch_timeout: Duration::from_secs(45 * 60),
+            poll_interval: Duration::from_secs(30),
+            cooldown: Duration::from_secs(30 * 60),
+        }
+    }
+}
+
+/// Bundles every seam [`reinstall_machine`] depends on. All trait objects so
+/// tests inject mocks; `handle_reinstall` is the only caller that constructs
+/// the real [`RuntimePowerControl`].
+pub struct ReinstallDeps<'a> {
+    pub web: &'a dyn WebClient,
+    pub pxe: &'a dyn PxeClient,
+    pub power: &'a dyn PowerControl,
+    pub watch: &'a dyn InstallWatch,
+    pub registry: &'a dyn ReinstallRegistry,
+    pub fleet: &'a FleetConfig,
+    pub clock: &'a dyn Clock,
+    pub config: ReinstallConfig,
+}
+
+const LOCAL_DISK: &str = "local-disk";
+const CUSTOM_AUTOINSTALL: &str = "custom-autoinstall";
+
+// ── Driver ───────────────────────────────────────────────────────────────────
+
+/// Drive one one-click reinstall attempt per spec C3 / Decision 13.
+///
+/// Sequence (spelled out per the brief, mirrored in the module docs above):
+/// (1) guards — deny-list, not-approved, cooldown-without-confirm — each
+/// returns before any mutating call; (2) registry write `boot_target =
+/// custom-autoinstall`; (3) dual projection (web + pxe); on a single-layer
+/// failure, both are flipped back best-effort, the registry field is
+/// restored, and `Unreconciled` is returned — power is never invoked; (4)
+/// power off then on (never reset/cycle); (5) bounded watch — success returns
+/// `Done`, failure/timeout runs the fail-safe flip-back and returns
+/// `TimedOutFlippedBack`. Every attempt that reaches the power step stamps
+/// the cooldown timestamp, regardless of the eventual watch outcome.
+pub async fn reinstall_machine(
+    deps: &ReinstallDeps<'_>,
+    req: ReinstallRequest,
+) -> anyhow::Result<ReinstallOutcome> {
+    let mac = req.mac.as_str();
+
+    // A registry read is not a side effect (the Goal's "before any side
+    // effect" refers to mutations) — but it must happen before any guard can
+    // be evaluated, since the deny-list is hostname-keyed and approval lives
+    // on the row.
+    let machine = deps.registry.get_machine(mac).await?;
+    let machine = match machine {
+        Some(m) => m,
+        None => return Ok(ReinstallOutcome::Refused(RefusalReason::NotApproved)),
+    };
+
+    // Guard 1: deny-list, sourced from FleetConfig — never hardcoded here.
+    if deps
+        .fleet
+        .reinstall_deny
+        .iter()
+        .any(|h| h == &machine.hostname)
+    {
+        return Ok(ReinstallOutcome::Refused(RefusalReason::DenyListed));
+    }
+
+    // Guard 2: approval status.
+    if !machine.approved {
+        return Ok(ReinstallOutcome::Refused(RefusalReason::NotApproved));
+    }
+
+    // Guard 3: cooldown, unless explicitly confirmed.
+    if let Some(last) = machine.last_reinstall_at {
+        let elapsed = deps.clock.now().duration_since(last).unwrap_or_default();
+        if elapsed < deps.config.cooldown && !req.confirm {
+            let remaining = deps.config.cooldown - elapsed;
+            let remaining_min = remaining.as_secs().div_ceil(60);
+            return Ok(ReinstallOutcome::Refused(RefusalReason::CooldownActive {
+                remaining_min,
+            }));
+        }
+    }
+
+    // Guards passed. Remember the prior boot_target so a reconciliation
+    // failure can restore it exactly.
+    let prior_boot_target = machine.boot_target.clone();
+
+    // Registry write: boot_target = custom-autoinstall (the single
+    // authoritative field).
+    deps.registry.set_boot_target(mac, CUSTOM_AUTOINSTALL).await?;
+
+    // Dual projection.
+    let web_res = deps.web.flip_boot_target(mac, CUSTOM_AUTOINSTALL).await;
+    let pxe_res = deps.pxe.set_boot_target(mac, CUSTOM_AUTOINSTALL).await;
+
+    if web_res.is_err() || pxe_res.is_err() {
+        // Never-half-projected: flip back whichever layer(s) actually
+        // succeeded forward (a layer that already errored never got
+        // projected, so there is nothing to undo there), restore the
+        // registry field, and refuse with the reconciliation error. Power is
+        // NOT invoked on this path.
+        let mut flip_back_errors = Vec::new();
+
+        if web_res.is_ok() {
+            if let Err(e) = deps.web.flip_boot_target(mac, LOCAL_DISK).await {
+                flip_back_errors.push(format!("web flip-back failed: {e}"));
+            }
+        }
+        if pxe_res.is_ok() {
+            if let Err(e) = deps.pxe.set_boot_target(mac, LOCAL_DISK).await {
+                flip_back_errors.push(format!("pxe flip-back failed: {e}"));
+            }
+        }
+        if let Err(e) = deps.registry.set_boot_target(mac, &prior_boot_target).await {
+            flip_back_errors.push(format!("registry restore failed: {e}"));
+        }
+
+        for err in &flip_back_errors {
+            tracing::error!("reinstall reconciliation flip-back: {err}");
+        }
+
+        let reason = format!(
+            "boot_target reconciliation failed for {mac} ({}): web={:?} pxe={:?}",
+            machine.hostname,
+            web_res.as_ref().err().map(|e| e.to_string()),
+            pxe_res.as_ref().err().map(|e| e.to_string()),
+        );
+        tracing::error!("{reason}");
+        return Ok(ReinstallOutcome::Refused(RefusalReason::Unreconciled(reason)));
+    }
+
+    // Power cycle: off then on, explicitly — reset/cycle are unrepresentable.
+    deps.power.off(&machine.hostname).await?;
+    deps.power.on(&machine.hostname).await?;
+
+    // Every attempt that reached the power step stamps the cooldown
+    // timestamp, regardless of the eventual watch outcome.
+    deps.registry.stamp_reinstall(mac, deps.clock.now()).await?;
+
+    // Bounded watch.
+    let start = deps.clock.now();
+    loop {
+        if let Some(status) = deps.watch.latest_status(mac).await? {
+            match status {
+                InstallStatus::Success => return Ok(ReinstallOutcome::Done),
+                InstallStatus::Failed => {
+                    return Ok(fail_safe_flip_back(deps, mac, &machine.hostname).await);
+                }
+                InstallStatus::InProgress => {}
+            }
+        }
+
+        let elapsed = deps.clock.now().duration_since(start).unwrap_or_default();
+        if elapsed >= deps.config.watch_timeout {
+            return Ok(fail_safe_flip_back(deps, mac, &machine.hostname).await);
+        }
+
+        deps.clock.sleep(deps.config.poll_interval).await;
+    }
+}
+
+/// Fail-safe: flip both layers (and the registry) back to `local-disk`
+/// best-effort, loudly alert, and report whether the flip-back itself fully
+/// succeeded. Never swallows a flip-back failure — every leg's error is
+/// `tracing::error!`-logged AND folded into `flip_back_ok`.
+async fn fail_safe_flip_back(
+    deps: &ReinstallDeps<'_>,
+    mac: &str,
+    hostname: &str,
+) -> ReinstallOutcome {
+    let web_res = deps.web.flip_boot_target(mac, LOCAL_DISK).await;
+    let pxe_res = deps.pxe.set_boot_target(mac, LOCAL_DISK).await;
+    let registry_res = deps.registry.set_boot_target(mac, LOCAL_DISK).await;
+
+    if let Err(e) = &web_res {
+        tracing::error!("fail-safe flip-back: web layer failed for {hostname} ({mac}): {e}");
+    }
+    if let Err(e) = &pxe_res {
+        tracing::error!("fail-safe flip-back: pxe layer failed for {hostname} ({mac}): {e}");
+    }
+    if let Err(e) = &registry_res {
+        tracing::error!(
+            "fail-safe flip-back: registry restore failed for {hostname} ({mac}): {e}"
+        );
+    }
+
+    let flip_back_ok = web_res.is_ok() && pxe_res.is_ok() && registry_res.is_ok();
+    tracing::error!(
+        "ALERT: reinstall watch bounded-timeout/failure for {hostname} ({mac}); fail-safe \
+         flip-back {}",
+        if flip_back_ok {
+            "succeeded"
+        } else {
+            "PARTIALLY FAILED — manual intervention required"
+        }
+    );
+
+    ReinstallOutcome::TimedOutFlippedBack { flip_back_ok }
+}
+
+// ── Runtime power impl + thin entry point ───────────────────────────────────
+
+/// Real [`PowerControl`] impl: pure construction/delegation to
+/// `uaa_core::power::run_power_action` — no IPMI logic lives here. Every call
+/// opens a fresh SSH session to `POWER_SERVER` (172.16.2.30), matching the
+/// existing CLI `uaa power` command's pattern.
+pub struct RuntimePowerControl {
+    ipmi_password: Option<String>,
+}
+
+impl RuntimePowerControl {
+    pub fn new(ipmi_password: Option<String>) -> Self {
+        Self { ipmi_password }
+    }
+
+    async fn run(&self, host: &str, action: uaa_core::power::PowerAction) -> anyhow::Result<()> {
+        use uaa_core::network::SshClient;
+        use uaa_core::power::{run_power_action, POWER_SERVER};
+
+        let mut client = SshClient::new();
+        client.connect(POWER_SERVER, "jdfalk").await?;
+        run_power_action(&mut client, host, action, self.ipmi_password.as_deref()).await?;
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl PowerControl for RuntimePowerControl {
+    async fn off(&self, host: &str) -> anyhow::Result<()> {
+        self.run(host, uaa_core::power::PowerAction::Off).await
+    }
+
+    async fn on(&self, host: &str) -> anyhow::Result<()> {
+        self.run(host, uaa_core::power::PowerAction::On).await
+    }
+}
+
+/// Thin entry point the operator plane (CT-07) and gRPC layer will call.
+/// Construction only: builds the real [`RuntimePowerControl`] and delegates
+/// straight to [`reinstall_machine`] — no orchestration logic lives here.
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_reinstall(
+    registry: &dyn ReinstallRegistry,
+    web: &dyn WebClient,
+    pxe: &dyn PxeClient,
+    watch: &dyn InstallWatch,
+    fleet: &FleetConfig,
+    clock: &dyn Clock,
+    config: ReinstallConfig,
+    ipmi_password: Option<String>,
+    req: ReinstallRequest,
+) -> anyhow::Result<ReinstallOutcome> {
+    let power = RuntimePowerControl::new(ipmi_password);
+    let deps = ReinstallDeps {
+        web,
+        pxe,
+        power: &power,
+        watch,
+        registry,
+        fleet,
+        clock,
+        config,
+    };
+    reinstall_machine(&deps, req).await
+}
+
+// ── Unit tests (all-mock, tick clock, zero hardware/SSH/network) ───────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::{Arc, Mutex};
+
+    const TEST_MAC: &str = "aa:bb:cc:dd:ee:ff";
+    const TEST_HOST: &str = "len-serv-999";
+
+    /// Shared, cloneable call-log: multiple mocks can be handed the same
+    /// `CallLog` (cloning only the inner `Arc`) so a single ordered sequence
+    /// can be asserted across every seam, or each mock can get its own fresh
+    /// log for isolated zero-call assertions.
+    #[derive(Clone, Default)]
+    struct CallLog(Arc<Mutex<Vec<String>>>);
+
+    impl CallLog {
+        fn push(&self, s: impl Into<String>) {
+            self.0.lock().unwrap().push(s.into());
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    struct MockWeb {
+        log: CallLog,
+        fail_on: Vec<String>,
+    }
+
+    impl MockWeb {
+        fn new(log: CallLog) -> Self {
+            Self {
+                log,
+                fail_on: Vec::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl WebClient for MockWeb {
+        async fn flip_boot_target(&self, _mac: &str, target: &str) -> anyhow::Result<()> {
+            self.log.push(format!("web:{target}"));
+            if self.fail_on.iter().any(|t| t == target) {
+                anyhow::bail!("mock web flip failure for target {target}");
+            }
+            Ok(())
+        }
+    }
+
+    struct MockPxe {
+        log: CallLog,
+        fail_on: Vec<String>,
+    }
+
+    impl MockPxe {
+        fn new(log: CallLog) -> Self {
+            Self {
+                log,
+                fail_on: Vec::new(),
+            }
+        }
+
+        fn failing_on(log: CallLog, target: &str) -> Self {
+            Self {
+                log,
+                fail_on: vec![target.to_string()],
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PxeClient for MockPxe {
+        async fn set_boot_target(&self, _mac: &str, target: &str) -> anyhow::Result<()> {
+            self.log.push(format!("pxe:{target}"));
+            if self.fail_on.iter().any(|t| t == target) {
+                anyhow::bail!("mock pxe set failure for target {target}");
+            }
+            Ok(())
+        }
+    }
+
+    struct MockPower {
+        log: CallLog,
+    }
+
+    impl MockPower {
+        fn new(log: CallLog) -> Self {
+            Self { log }
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl PowerControl for MockPower {
+        async fn off(&self, host: &str) -> anyhow::Result<()> {
+            self.log.push(format!("power:off:{host}"));
+            Ok(())
+        }
+
+        async fn on(&self, host: &str) -> anyhow::Result<()> {
+            self.log.push(format!("power:on:{host}"));
+            Ok(())
+        }
+    }
+
+    struct MockWatch {
+        log: CallLog,
+        responses: Mutex<VecDeque<Option<InstallStatus>>>,
+        default: Option<InstallStatus>,
+    }
+
+    impl MockWatch {
+        /// Always report a fixed status (or `None` forever, for a timeout test).
+        fn always(log: CallLog, status: Option<InstallStatus>) -> Self {
+            Self {
+                log,
+                responses: Mutex::new(VecDeque::new()),
+                default: status,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl InstallWatch for MockWatch {
+        async fn latest_status(&self, mac: &str) -> anyhow::Result<Option<InstallStatus>> {
+            self.log.push(format!("watch:{mac}"));
+            let mut q = self.responses.lock().unwrap();
+            Ok(q.pop_front().unwrap_or_else(|| self.default.clone()))
+        }
+    }
+
+    struct MockRegistry {
+        machines: Mutex<HashMap<String, RegistryMachine>>,
+        get_calls: CallLog,
+        write_calls: CallLog,
+    }
+
+    impl MockRegistry {
+        fn new(mac: &str, machine: RegistryMachine) -> Self {
+            let mut m = HashMap::new();
+            m.insert(mac.to_string(), machine);
+            Self {
+                machines: Mutex::new(m),
+                get_calls: CallLog::default(),
+                write_calls: CallLog::default(),
+            }
+        }
+
+        fn with_shared_write_log(mac: &str, machine: RegistryMachine, write_calls: CallLog) -> Self {
+            let mut m = HashMap::new();
+            m.insert(mac.to_string(), machine);
+            Self {
+                machines: Mutex::new(m),
+                get_calls: CallLog::default(),
+                write_calls,
+            }
+        }
+
+        fn boot_target_now(&self, mac: &str) -> String {
+            self.machines
+                .lock()
+                .unwrap()
+                .get(mac)
+                .map(|m| m.boot_target.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    #[async_trait]
+    impl ReinstallRegistry for MockRegistry {
+        async fn get_machine(&self, mac: &str) -> anyhow::Result<Option<RegistryMachine>> {
+            self.get_calls.push(format!("get:{mac}"));
+            Ok(self.machines.lock().unwrap().get(mac).cloned())
+        }
+
+        async fn set_boot_target(&self, mac: &str, target: &str) -> anyhow::Result<()> {
+            self.write_calls.push(format!("registry:set_boot_target:{target}"));
+            if let Some(m) = self.machines.lock().unwrap().get_mut(mac) {
+                m.boot_target = target.to_string();
+            }
+            Ok(())
+        }
+
+        async fn stamp_reinstall(&self, mac: &str, at: SystemTime) -> anyhow::Result<()> {
+            self.write_calls.push("registry:stamp_reinstall".to_string());
+            if let Some(m) = self.machines.lock().unwrap().get_mut(mac) {
+                m.last_reinstall_at = Some(at);
+            }
+            Ok(())
+        }
+    }
+
+    /// Test [`Clock`]: `sleep()` advances a virtual clock instantly instead
+    /// of actually waiting, so the bounded-watch tests run in microseconds.
+    struct TickClock {
+        now: Mutex<SystemTime>,
+    }
+
+    impl TickClock {
+        fn new(start: SystemTime) -> Self {
+            Self {
+                now: Mutex::new(start),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Clock for TickClock {
+        fn now(&self) -> SystemTime {
+            *self.now.lock().unwrap()
+        }
+
+        async fn sleep(&self, dur: Duration) {
+            let mut n = self.now.lock().unwrap();
+            *n += dur;
+        }
+    }
+
+    fn approved_machine() -> RegistryMachine {
+        RegistryMachine {
+            hostname: TEST_HOST.to_string(),
+            approved: true,
+            boot_target: LOCAL_DISK.to_string(),
+            last_reinstall_at: None,
+        }
+    }
+
+    fn small_config() -> ReinstallConfig {
+        ReinstallConfig {
+            watch_timeout: Duration::from_secs(120),
+            poll_interval: Duration::from_secs(30),
+            cooldown: Duration::from_secs(30 * 60),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_denylist_refused_zero_side_effects() {
+        let fleet = FleetConfig::default(); // includes "unimatrixone" by default.
+        let registry = MockRegistry::new(
+            TEST_MAC,
+            RegistryMachine {
+                hostname: "unimatrixone".to_string(),
+                approved: true,
+                boot_target: LOCAL_DISK.to_string(),
+                last_reinstall_at: None,
+            },
+        );
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), None);
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ReinstallOutcome::Refused(RefusalReason::DenyListed)
+        );
+        // Zero side effects: no mutating registry call, and every other seam
+        // (which is entirely action/mutation-shaped) recorded nothing.
+        assert!(registry.write_calls.calls().is_empty());
+        assert!(web.log.calls().is_empty());
+        assert!(pxe.log.calls().is_empty());
+        assert!(power.log.calls().is_empty());
+        assert!(watch.log.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unapproved_refused_zero_side_effects() {
+        let fleet = FleetConfig::default();
+        let mut machine = approved_machine();
+        machine.approved = false;
+        let registry = MockRegistry::new(TEST_MAC, machine);
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), None);
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ReinstallOutcome::Refused(RefusalReason::NotApproved)
+        );
+        assert!(registry.write_calls.calls().is_empty());
+        assert!(web.log.calls().is_empty());
+        assert!(pxe.log.calls().is_empty());
+        assert!(power.log.calls().is_empty());
+        assert!(watch.log.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cooldown_refused_without_confirm() {
+        let fleet = FleetConfig::default();
+        let start = SystemTime::now();
+        let mut machine = approved_machine();
+        machine.last_reinstall_at = Some(start);
+        let registry = MockRegistry::new(TEST_MAC, machine);
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), None);
+        // Clock is 5 minutes past last_reinstall_at; cooldown is 30 minutes.
+        let clock = TickClock::new(start + Duration::from_secs(5 * 60));
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ReinstallOutcome::Refused(RefusalReason::CooldownActive { remaining_min: 25 })
+        );
+        assert!(registry.write_calls.calls().is_empty());
+        assert!(web.log.calls().is_empty());
+        assert!(pxe.log.calls().is_empty());
+        assert!(power.log.calls().is_empty());
+        assert!(watch.log.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cooldown_bypassed_with_confirm() {
+        let fleet = FleetConfig::default();
+        let start = SystemTime::now();
+        let mut machine = approved_machine();
+        machine.last_reinstall_at = Some(start);
+        let registry = MockRegistry::new(TEST_MAC, machine);
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), Some(InstallStatus::Success));
+        let clock = TickClock::new(start + Duration::from_secs(5 * 60));
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, ReinstallOutcome::Done);
+        // confirm:true bypassed the cooldown guard and drove all the way through.
+        assert!(!web.log.calls().is_empty());
+        assert!(!pxe.log.calls().is_empty());
+        assert!(!power.log.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_single_layer_failure_flips_back_and_restores() {
+        let fleet = FleetConfig::default();
+        let registry = MockRegistry::new(TEST_MAC, approved_machine());
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::failing_on(CallLog::default(), CUSTOM_AUTOINSTALL);
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), None);
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        match outcome {
+            ReinstallOutcome::Refused(RefusalReason::Unreconciled(_)) => {}
+            other => panic!("expected Unreconciled, got {other:?}"),
+        }
+
+        // web was flipped forward then back; pxe only attempted (and failed) forward.
+        assert_eq!(web.log.calls(), vec!["web:custom-autoinstall", "web:local-disk"]);
+        assert_eq!(pxe.log.calls(), vec!["pxe:custom-autoinstall"]);
+        // Registry: forward write, then restore back to the prior value.
+        assert_eq!(
+            registry.write_calls.calls(),
+            vec![
+                "registry:set_boot_target:custom-autoinstall",
+                "registry:set_boot_target:local-disk",
+            ]
+        );
+        assert_eq!(registry.boot_target_now(TEST_MAC), LOCAL_DISK);
+        // Power is never invoked on this path.
+        assert!(power.log.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_power_off_then_on_order() {
+        let fleet = FleetConfig::default();
+        let registry = MockRegistry::new(TEST_MAC, approved_machine());
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), Some(InstallStatus::Success));
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            power.log.calls(),
+            vec![
+                format!("power:off:{TEST_HOST}"),
+                format!("power:on:{TEST_HOST}"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watch_success_done() {
+        let fleet = FleetConfig::default();
+        let registry = MockRegistry::new(TEST_MAC, approved_machine());
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), Some(InstallStatus::Success));
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, ReinstallOutcome::Done);
+        assert_eq!(registry.boot_target_now(TEST_MAC), CUSTOM_AUTOINSTALL);
+    }
+
+    #[tokio::test]
+    async fn test_watch_timeout_flips_back_and_alerts() {
+        let fleet = FleetConfig::default();
+        let registry = MockRegistry::new(TEST_MAC, approved_machine());
+        let web = MockWeb::new(CallLog::default());
+        let pxe = MockPxe::new(CallLog::default());
+        let power = MockPower::new(CallLog::default());
+        // Never reports a status -> the watch loop runs out the bounded timeout.
+        let watch = MockWatch::always(CallLog::default(), None);
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(), // watch_timeout = 120s, poll_interval = 30s
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ReinstallOutcome::TimedOutFlippedBack { flip_back_ok: true }
+        );
+        // Both layers re-flipped to local-disk after the forward flip.
+        assert_eq!(
+            web.log.calls(),
+            vec!["web:custom-autoinstall", "web:local-disk"]
+        );
+        assert_eq!(
+            pxe.log.calls(),
+            vec!["pxe:custom-autoinstall", "pxe:local-disk"]
+        );
+        assert_eq!(registry.boot_target_now(TEST_MAC), LOCAL_DISK);
+    }
+
+    #[tokio::test]
+    async fn test_flip_back_failure_surfaced() {
+        let fleet = FleetConfig::default();
+        let registry = MockRegistry::new(TEST_MAC, approved_machine());
+        let web = MockWeb::new(CallLog::default());
+        // Forward pxe write to custom-autoinstall succeeds; the fail-safe
+        // flip-back call to local-disk fails.
+        let pxe = MockPxe::failing_on(CallLog::default(), LOCAL_DISK);
+        let power = MockPower::new(CallLog::default());
+        let watch = MockWatch::always(CallLog::default(), Some(InstallStatus::Failed));
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            ReinstallOutcome::TimedOutFlippedBack {
+                flip_back_ok: false
+            }
+        );
+        // The failed flip-back attempt was still made (and recorded) — never
+        // swallowed.
+        assert_eq!(
+            pxe.log.calls(),
+            vec!["pxe:custom-autoinstall", "pxe:local-disk"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_approved_host_reinstall_happy_path() {
+        let fleet = FleetConfig::default();
+        let shared = CallLog::default();
+        let registry =
+            MockRegistry::with_shared_write_log(TEST_MAC, approved_machine(), shared.clone());
+        let web = MockWeb::new(shared.clone());
+        let pxe = MockPxe::new(shared.clone());
+        let power = MockPower::new(shared.clone());
+        let watch = MockWatch::always(shared.clone(), Some(InstallStatus::Success));
+        let clock = TickClock::new(SystemTime::now());
+
+        let deps = ReinstallDeps {
+            web: &web,
+            pxe: &pxe,
+            power: &power,
+            watch: &watch,
+            registry: &registry,
+            fleet: &fleet,
+            clock: &clock,
+            config: small_config(),
+        };
+
+        let outcome = reinstall_machine(
+            &deps,
+            ReinstallRequest {
+                mac: TEST_MAC.to_string(),
+                confirm: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, ReinstallOutcome::Done);
+
+        let calls = shared.calls();
+        assert_eq!(
+            calls,
+            vec![
+                "registry:set_boot_target:custom-autoinstall".to_string(),
+                "web:custom-autoinstall".to_string(),
+                "pxe:custom-autoinstall".to_string(),
+                format!("power:off:{TEST_HOST}"),
+                format!("power:on:{TEST_HOST}"),
+                "registry:stamp_reinstall".to_string(),
+                format!("watch:{TEST_MAC}"),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Wave 4, coordinator-assembled (the 9 wave-4 workers all hit the account session limit mid-task; I committed + integrated the completed ones). Five disjoint uaa-control fillers + the lifecycle router wiring, dep-union'd, clippy-fixed (collapsed str::replace, allow large-err on the axum-Response parse_json):
- CT-02 registry CRUD + import(insert-if-absent)/export
- CT-03 GitHub OAuth + org/team RBAC (fail-closed to viewer)
- CT-04 FOR-UPDATE-serialized hash-chain audit + signed checkpoints
- CT-06 ReinstallMachine (flip+power+bounded-watch, unimatrixone-refused)
- IP-02 register/checkin/webhook parity (TPM-bind, auto-flip) → wired into machine_plane router
Gate: 50 + 69 + 375 + 2 = 496; clippy --all-targets clean.
Deferred to re-dispatch (workers didn't finish before the limit): IP-01 seeds (router handler failed axum Handler trait bound), IP-03 inventory, CT-05 SAGA, PK-01 CA/EnrollService.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>