### PR TITLE
feat(control): wave-4 remainder (seeds/inventory/SAGA/CA+enroll) + wiring + 2 secfixes

### DIFF
--- a/crates/uaa-control/Cargo.toml
+++ b/crates/uaa-control/Cargo.toml
@@ -1,5 +1,5 @@
 # file: crates/uaa-control/Cargo.toml
-# version: 1.1.0
+# version: 1.1.1
 # guid: 1e1a4386-a459-4a97-8baf-c942283b3107
 # last-edited: 2026-07-10
 
@@ -54,10 +54,13 @@ rand = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
+# Wave-4 remainder: PKI CA/EnrollService (PK-01), cert-gen tempdir (IP-03)
+rcgen = { workspace = true, features = ["x509-parser"] }
+x509-parser = { workspace = true, features = ["verify"] }
+tempfile = { workspace = true }
 # Sibling crates
 uaa-proto = { path = "../uaa-proto" }
 uaa-core = { path = "../uaa-core" }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 tokio-test = { workspace = true }

--- a/crates/uaa-control/src/ca.rs
+++ b/crates/uaa-control/src/ca.rs
@@ -1,9 +1,370 @@
 // file: crates/uaa-control/src/ca.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 19da2b5c-91d8-4a97-ba3b-de299638e434
 // last-edited: 2026-07-10
 
 //! Dedicated install CA (rcgen) — mint/sign agent certs, CRL (Decision 6).
 //!
-//! STUB — Filled exclusively by pki PK-01, then PK-03 (serialized — collision row: the
-//! two pki tasks edit this file in sequence, never concurrently).
+//! Filled by pki PK-01 (this task): the CA lifecycle
+//! ([`InstallCa::load_or_create`], [`InstallCa::sign_agent_csr`],
+//! [`InstallCa::ca_cert_pem`]). `crates/uaa-control/src/enroll.rs` (also PK-01) is the
+//! only caller of this module. PK-03 extends this same file NEXT, serialized behind
+//! this task (collision row: CT-01 stub → PK-01 → PK-03) — it adds
+//! `issue_service`/CRL publish and REUSES [`InstallCa`] rather than writing a second
+//! CA type; the `pub` surface here is kept intentionally minimal and stable for that.
+//!
+//! # NEVER the CockroachDB CA (Decision 6, locked)
+//!
+//! This is a dedicated keypair generated once and persisted under a
+//! caller-supplied directory (production default `/var/lib/uaa/ca/`), loaded ONLY by
+//! uaa-control. No code path in this file reads any database-server CA material —
+//! the registry's CA (used to secure the SQL wire protocol) and this install CA
+//! (used to mint agent/service identity certs) are two completely separate,
+//! non-overlapping trust roots.
+//!
+//! # Custody (spec Decision 6 "Repair")
+//!
+//! An offline, encrypted backup of `ca.key` plus a documented restore procedure is a
+//! P0 ship-gate (M3) — that runbook is a coordinator-owned documentation deliverable,
+//! explicitly NOT built in this file. What this module guarantees mechanically:
+//! `ca.key` is written `0600`, the CA directory `0700`, and — critically — an
+//! existing CA is always LOADED, never regenerated (regenerating would silently
+//! orphan every certificate already issued against the old key).
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+
+use chrono::{Datelike, Duration as ChronoDuration, Utc};
+use rcgen::{
+    date_time_ymd, BasicConstraints, Certificate, CertificateParams,
+    CertificateSigningRequestParams, DistinguishedName, DnType, Ia5String, IsCa, KeyPair,
+    KeyUsagePurpose, SanType, PKCS_ECDSA_P256_SHA256,
+};
+
+const CA_KEY_FILE: &str = "ca.key";
+const CA_CERT_FILE: &str = "ca.crt";
+/// Owner-only directory mode for the CA's home (spec Decision 6).
+const CA_DIR_MODE: u32 = 0o700;
+/// Owner-only file mode for the CA private key (spec Decision 6).
+const CA_KEY_MODE: u32 = 0o600;
+/// World-readable mode for the CA certificate (it is the public trust anchor agents
+/// pin — distributing it widely is the point; only the key is secret).
+const CA_CERT_MODE: u32 = 0o644;
+/// Agent certificate lifetime (spec Decision 6 / C6): 90 days.
+const AGENT_CERT_LIFETIME_DAYS: i64 = 90;
+/// Install CA root lifetime. Long-lived by design — rotating the root itself is an
+/// operator-driven backup/restore event (the M3 ship-gate runbook), not code here.
+const CA_LIFETIME_DAYS: i64 = 3650;
+
+/// A loaded (or freshly created) install CA: keypair plus self-signed root, kept
+/// in-process as an [`rcgen::Certificate`] so [`InstallCa::sign_agent_csr`] can issue
+/// against it without re-reading the filesystem per call.
+///
+/// NEVER the CockroachDB CA (Decision 6) — see the module doc.
+pub struct InstallCa {
+    key_pair: KeyPair,
+    /// In-memory issuer identity (distinguished name / key-id method / key usages)
+    /// used to sign children — reconstructed on load, kept from creation otherwise.
+    cert: Certificate,
+    /// The exact PEM bytes persisted on disk (or just written on create) — this is
+    /// the authoritative trust-anchor text served to agents/operators, independent of
+    /// whatever a re-signed in-memory [`Certificate`] would currently serialize to.
+    cert_pem: String,
+}
+
+impl InstallCa {
+    /// Load an existing CA from `ca_dir`, or create one on first use.
+    ///
+    /// `ca_dir` is ALWAYS a constructor parameter — never hard-coded — so tests use
+    /// `tempfile::tempdir()`; the production default is `/var/lib/uaa/ca/`.
+    ///
+    /// Create-if-absent: when `ca.key`/`ca.crt` are both present they are loaded
+    /// VERBATIM (never regenerated). On first creation, `ca_dir` is made `0700`,
+    /// `ca.key` is written `0600`, `ca.crt` `0644`.
+    pub fn load_or_create(ca_dir: &Path) -> anyhow::Result<InstallCa> {
+        let key_path = ca_dir.join(CA_KEY_FILE);
+        let cert_path = ca_dir.join(CA_CERT_FILE);
+
+        if key_path.is_file() && cert_path.is_file() {
+            Self::load(&key_path, &cert_path)
+        } else {
+            Self::create(ca_dir, &key_path, &cert_path)
+        }
+    }
+
+    fn load(key_path: &Path, cert_path: &Path) -> anyhow::Result<InstallCa> {
+        let key_pem = fs::read_to_string(key_path)?;
+        let key_pair = KeyPair::from_pem(&key_pem).map_err(|e| {
+            anyhow::anyhow!("install CA key at {} is corrupt: {e}", key_path.display())
+        })?;
+
+        let cert_pem = fs::read_to_string(cert_path)?;
+        let params = CertificateParams::from_ca_cert_pem(&cert_pem).map_err(|e| {
+            anyhow::anyhow!("install CA cert at {} is corrupt: {e}", cert_path.display())
+        })?;
+        // Reconstruct an in-memory issuer `Certificate` from the loaded params/key —
+        // used only for its subject/key-id/key-usage identity when signing children,
+        // never written back to disk (the persisted `cert_pem` above stays the
+        // authoritative trust-anchor text).
+        let cert = params
+            .self_signed(&key_pair)
+            .map_err(|e| anyhow::anyhow!("failed to reconstruct install CA identity: {e}"))?;
+
+        Ok(InstallCa {
+            key_pair,
+            cert,
+            cert_pem,
+        })
+    }
+
+    fn create(ca_dir: &Path, key_path: &Path, cert_path: &Path) -> anyhow::Result<InstallCa> {
+        fs::create_dir_all(ca_dir)?;
+        fs::set_permissions(ca_dir, fs::Permissions::from_mode(CA_DIR_MODE))?;
+
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+            .map_err(|e| anyhow::anyhow!("install CA keypair generation failed: {e}"))?;
+
+        let mut params = CertificateParams::default();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "uaa install CA");
+        params.distinguished_name = dn;
+        params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        set_validity_days(&mut params, CA_LIFETIME_DAYS);
+
+        let cert = params
+            .self_signed(&key_pair)
+            .map_err(|e| anyhow::anyhow!("install CA self-signing failed: {e}"))?;
+        let cert_pem = cert.pem();
+        let key_pem = key_pair.serialize_pem();
+
+        write_owner_mode(key_path, key_pem.as_bytes(), CA_KEY_MODE)?;
+        write_owner_mode(cert_path, cert_pem.as_bytes(), CA_CERT_MODE)?;
+
+        Ok(InstallCa {
+            key_pair,
+            cert,
+            cert_pem,
+        })
+    }
+
+    /// Sign `csr_pem` into a 90-day agent certificate whose SAN is EXACTLY the DNS
+    /// `hostname` plus the URI `uaa-mac:<mac>` — the server-approved identity, not
+    /// whatever extensions the CSR itself happened to carry. `rcgen` verifies the
+    /// CSR's self-signature (proof of possession) as part of parsing; a CSR that does
+    /// not verify is rejected here, before anything is signed.
+    ///
+    /// NEVER the CockroachDB CA — this always signs with THIS install CA's key.
+    pub fn sign_agent_csr(&self, csr_pem: &str, hostname: &str, mac: &str) -> anyhow::Result<String> {
+        let mut csr = CertificateSigningRequestParams::from_pem(csr_pem)
+            .map_err(|e| anyhow::anyhow!("invalid CSR: {e}"))?;
+
+        let dns = Ia5String::try_from(hostname.to_string())
+            .map_err(|e| anyhow::anyhow!("hostname is not a valid SAN string: {e}"))?;
+        let mac_uri = Ia5String::try_from(format!("uaa-mac:{mac}"))
+            .map_err(|e| anyhow::anyhow!("mac is not a valid SAN string: {e}"))?;
+        csr.params.subject_alt_names = vec![SanType::DnsName(dns), SanType::URI(mac_uri)];
+        csr.params.is_ca = IsCa::NoCa;
+        set_validity_days(&mut csr.params, AGENT_CERT_LIFETIME_DAYS);
+
+        let signed = csr
+            .signed_by(&self.cert, &self.key_pair)
+            .map_err(|e| anyhow::anyhow!("signing agent certificate failed: {e}"))?;
+        Ok(signed.pem())
+    }
+
+    /// The install CA's own certificate, PEM-encoded — the trust anchor served to
+    /// agents/operators. NEVER the CockroachDB CA.
+    pub fn ca_cert_pem(&self) -> &str {
+        &self.cert_pem
+    }
+}
+
+/// Set `params.not_before`/`params.not_after` to a `[now, now + days]` window, at
+/// day granularity (`rcgen::date_time_ymd`) — plenty precise for a 90-day agent cert
+/// or a multi-year CA root, and avoids depending on the `time` crate directly (it is
+/// only a transitive dependency of `rcgen`, pulled in via type inference here).
+fn set_validity_days(params: &mut CertificateParams, days: i64) {
+    let now = Utc::now();
+    let end = now + ChronoDuration::days(days);
+    params.not_before = date_time_ymd(now.year(), now.month() as u8, now.day() as u8);
+    params.not_after = date_time_ymd(end.year(), end.month() as u8, end.day() as u8);
+}
+
+/// Write `contents` to `path` with `mode`, creating/truncating as needed, then
+/// re-assert the mode via `set_permissions` (belt-and-suspenders against an
+/// umask-affected `OpenOptions::mode` on some platforms — mirrors the pattern
+/// already used by `crate::audit`/`crate::db::store`).
+fn write_owner_mode(path: &Path, contents: &[u8], mode: u32) -> anyhow::Result<()> {
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(mode)
+        .open(path)?;
+    f.write_all(contents)?;
+    f.flush()?;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use uaa_core::pki::{generate_keypair_and_csr, AgentIdentity};
+    use x509_parser::pem::parse_x509_pem;
+
+    fn mode_of(path: &Path) -> u32 {
+        fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    fn dir_mode_of(path: &Path) -> u32 {
+        mode_of(path)
+    }
+
+    fn test_csr() -> (String, AgentIdentity) {
+        let identity = AgentIdentity {
+            hostname: "testhost".to_string(),
+            mac: "aa:bb:cc:dd:ee:ff".to_string(),
+        };
+        let (_key_pem, csr_pem) = generate_keypair_and_csr(&identity).unwrap();
+        (csr_pem, identity)
+    }
+
+    #[test]
+    fn test_ca_load_or_create_idempotent() {
+        let dir = tempdir().unwrap();
+        let ca_dir = dir.path().join("ca");
+
+        let first = InstallCa::load_or_create(&ca_dir).unwrap();
+        let first_pem = first.ca_cert_pem().to_string();
+
+        assert_eq!(dir_mode_of(&ca_dir), 0o700, "CA dir must be 0700");
+        assert_eq!(mode_of(&ca_dir.join("ca.key")), 0o600, "ca.key must be 0600");
+        assert_eq!(mode_of(&ca_dir.join("ca.crt")), 0o644, "ca.crt must be 0644");
+
+        // Second load must return the IDENTICAL cert text — never regenerated (a
+        // regenerated CA would orphan every already-issued cert).
+        let second = InstallCa::load_or_create(&ca_dir).unwrap();
+        assert_eq!(second.ca_cert_pem(), first_pem, "load must never regenerate the CA");
+    }
+
+    #[test]
+    fn test_ca_cert_pem_is_not_a_second_registry_trust_root() {
+        let dir = tempdir().unwrap();
+        let ca = InstallCa::load_or_create(&dir.path().join("ca")).unwrap();
+        assert!(ca.ca_cert_pem().contains("BEGIN CERTIFICATE"));
+    }
+
+    #[test]
+    fn test_approve_signs_90d_san() {
+        let dir = tempdir().unwrap();
+        let ca = InstallCa::load_or_create(&dir.path().join("ca")).unwrap();
+        let (csr_pem, identity) = test_csr();
+
+        let cert_pem = ca
+            .sign_agent_csr(&csr_pem, &identity.hostname, &identity.mac)
+            .unwrap();
+
+        let (_, pem) = parse_x509_pem(cert_pem.as_bytes()).unwrap();
+        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents).unwrap();
+        let validity = cert.validity();
+        let lifetime_days =
+            (validity.not_after.timestamp() - validity.not_before.timestamp()) / 86_400;
+        assert!(
+            (89..=91).contains(&lifetime_days),
+            "expected ~90d lifetime, got {lifetime_days}d"
+        );
+
+        let mut found_dns = false;
+        let mut found_uri = false;
+        for ext in cert.extensions() {
+            if let x509_parser::extensions::ParsedExtension::SubjectAlternativeName(san) =
+                ext.parsed_extension()
+            {
+                for name in &san.general_names {
+                    match name {
+                        x509_parser::extensions::GeneralName::DNSName(dns)
+                            if *dns == identity.hostname =>
+                        {
+                            found_dns = true
+                        }
+                        x509_parser::extensions::GeneralName::URI(uri)
+                            if *uri == format!("uaa-mac:{}", identity.mac) =>
+                        {
+                            found_uri = true
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(found_dns, "expected DNS SAN = hostname");
+        assert!(found_uri, "expected URI SAN = uaa-mac:<mac>");
+    }
+
+    #[test]
+    fn test_sign_agent_csr_rejects_garbage() {
+        let dir = tempdir().unwrap();
+        let ca = InstallCa::load_or_create(&dir.path().join("ca")).unwrap();
+        let result = ca.sign_agent_csr("not a csr", "host", "aa:bb:cc:dd:ee:ff");
+        assert!(result.is_err());
+    }
+
+    /// Production-dominant path: `create` runs ONCE ever; every subsequent daemon
+    /// start hits `load`, which reconstructs the in-memory issuer via
+    /// `from_ca_cert_pem(...).self_signed(&key_pair)`. This proves that
+    /// reconstruction actually chains correctly — a cert signed AFTER a fresh
+    /// `load_or_create` (second process, same `ca_dir`) must validate against the
+    /// SAME persisted `ca_cert_pem` and carry the right SANs.
+    #[test]
+    fn test_sign_agent_csr_after_reload_chains_to_persisted_ca() {
+        let dir = tempdir().unwrap();
+        let ca_dir = dir.path().join("ca");
+
+        // First "process": create the CA, note its persisted trust-anchor text.
+        let created = InstallCa::load_or_create(&ca_dir).unwrap();
+        let persisted_ca_pem = created.ca_cert_pem().to_string();
+        drop(created);
+
+        // Second "process": load (never regenerate) the SAME CA from disk.
+        let loaded = InstallCa::load_or_create(&ca_dir).unwrap();
+        assert_eq!(loaded.ca_cert_pem(), persisted_ca_pem, "load must not regenerate");
+
+        let (csr_pem, identity) = test_csr();
+        let cert_pem = loaded
+            .sign_agent_csr(&csr_pem, &identity.hostname, &identity.mac)
+            .unwrap();
+
+        // The child must verify against the PERSISTED CA cert (not just whatever
+        // `loaded` happens to hold in memory) — parse both and check the issuer's
+        // public key signed the child.
+        let (_, ca_pem_parsed) = parse_x509_pem(persisted_ca_pem.as_bytes()).unwrap();
+        let (_, ca_cert) = x509_parser::parse_x509_certificate(&ca_pem_parsed.contents).unwrap();
+        let (_, child_pem) = parse_x509_pem(cert_pem.as_bytes()).unwrap();
+        let (_, child_cert) = x509_parser::parse_x509_certificate(&child_pem.contents).unwrap();
+        assert!(
+            child_cert.verify_signature(Some(ca_cert.public_key())).is_ok(),
+            "cert signed by a RELOADED CA must verify against the persisted ca.crt"
+        );
+
+        let mut found_dns = false;
+        for ext in child_cert.extensions() {
+            if let x509_parser::extensions::ParsedExtension::SubjectAlternativeName(san) =
+                ext.parsed_extension()
+            {
+                for name in &san.general_names {
+                    if let x509_parser::extensions::GeneralName::DNSName(dns) = name {
+                        if *dns == identity.hostname {
+                            found_dns = true;
+                        }
+                    }
+                }
+            }
+        }
+        assert!(found_dns, "reloaded-CA-signed cert must still carry the hostname SAN");
+    }
+}

--- a/crates/uaa-control/src/enroll.rs
+++ b/crates/uaa-control/src/enroll.rs
@@ -1,8 +1,1007 @@
 // file: crates/uaa-control/src/enroll.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1a81d662-89c9-4e64-8ce9-9aa51fd3a412
 // last-edited: 2026-07-10
 
-//! Enrollment plane (:7444) — CSR submit + GetCredential poll, idempotent by SPKI fp.
+//! Enrollment plane (`uaa.enroll.v1` gRPC + `:7444` JSON mirror) — CSR submit +
+//! GetCredential poll, idempotent by SPKI fingerprint (spec C6, NORMATIVE).
 //!
-//! STUB — Filled exclusively by pki PK-01.
+//! Filled by pki PK-01 (this task), on top of PK-01's own [`crate::ca::InstallCa`].
+//! Everything here is storage-agnostic against [`EnrollmentStore`] (this module's own
+//! trait — the `enrollments` table has no existing CT-01 CRUD trait to reuse, so this
+//! follows the SAME pattern CT-01 established for `RegistryStore`/`AuditStore`: a
+//! trait plus an always-compiled in-memory mock, so `cargo test --lib --offline`
+//! needs NO live database). Every mutation goes through
+//! [`crate::audit::record`] (CT-01's audit hook, PK-01 reuses it — no parallel log).
+//!
+//! # State machine (spec C6, implemented verbatim)
+//!
+//! ```text
+//! pending --(approve)--> issued --(revoke)--> revoked
+//!    |                     |
+//!    |                     `--(a NEW fp approved for the same MAC)--> superseded
+//!    `--(reject)--> rejected
+//! ```
+//!
+//! * `pending` — freshly submitted, awaiting an operator decision.
+//! * `approved` — reserved by the schema (spec "Data model"); this task's `approve`
+//!   signs and transitions straight `pending -> issued` in one atomic operator
+//!   action (per spec C6's "approve/reject -> control signs ... and returns cert" —
+//!   there is no separate sign step). Treated identically to `pending` by
+//!   `GetCredential` (no cert bytes yet) for forward compatibility with a future
+//!   two-phase approval flow.
+//! * `issued` — signed; `cert_pem` set.
+//! * `rejected` / `revoked` — terminal UNTIL an operator explicitly calls
+//!   [`approve`] again (spec: "operator can re-approve").
+//! * `superseded` — an `issued` row's replacement: approving a NEW fp for a MAC that
+//!   already has an `issued` row marks the OLD row `superseded` first (reinstalls
+//!   wipe the agent state dir and mint a new key — rows must not accrete).
+//!
+//! # Fail-closed poll (spec C3 enrollment plane)
+//!
+//! [`get_credential`] for an UNKNOWN SPKI fingerprint returns `Ok(None)` — the JSON
+//! handler maps this to `404`, the gRPC handler to `Status::not_found`. Neither path
+//! ever auto-issues or auto-creates a row for an unknown fingerprint.
+//!
+//! # Renewal (same-key auto-issue)
+//!
+//! [`submit_csr`] on an ALREADY-KNOWN fingerprint is an idempotent upsert: it never
+//! resets a decided row back to `pending`, and normally just returns the current
+//! state unchanged — EXCEPT when that row is `issued` with a still-unexpired cert
+//! (an `issued` row is by definition not revoked), in which case a fresh 90-day cert
+//! is minted with NO operator round-trip (spec: "renewal ... auto-issue iff an
+//! unexpired unrevoked cert exists for the SPKI"). Because the lookup key IS the
+//! SHA-256 of the CSR's public key, "same fingerprint" and "identical public key"
+//! are the same fact — no separate key-equality check is needed.
+//!
+//! NEVER the CockroachDB CA — every signature in this module goes through
+//! [`crate::ca::InstallCa`], never a second trust root.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::audit::AuditStore;
+use crate::ca::InstallCa;
+use crate::db::{EnrollmentRow, EnrollmentState};
+
+// ── Persistence seam (reuses CT-01's trait+mock pattern; no existing enrollments
+// CRUD trait to reuse verbatim — this is the analogous trait for THIS table) ──────
+
+/// Persistence seam for the `enrollments` table (spec "Data model": PRIMARY KEY
+/// `spki_fingerprint`). Mirrors CT-01's `RegistryStore`/`AuditStore` shape exactly:
+/// `insert_if_absent` returns `Ok(true)` iff the row was newly inserted (Decision 22
+/// no-clobber law — `Ok(false)` means a row for that fp already existed and was left
+/// COMPLETELY untouched).
+#[async_trait::async_trait]
+pub trait EnrollmentStore: Send + Sync {
+    /// Look up by SPKI fingerprint (the primary key).
+    async fn get(&self, spki_fingerprint: &str) -> anyhow::Result<Option<EnrollmentRow>>;
+    /// `Ok(true)` = inserted; `Ok(false)` = a row for this fp already existed
+    /// (Decision 22 no-clobber law) and was left untouched.
+    async fn insert_if_absent(&self, row: EnrollmentRow) -> anyhow::Result<bool>;
+    /// Full replace of an existing row (state transitions, `cert_pem`, `decided_by`).
+    async fn update(&self, row: EnrollmentRow) -> anyhow::Result<()>;
+    /// Every row currently `issued` for `mac` — used by [`approve`]'s supersede rule.
+    async fn list_issued_for_mac(&self, mac: &str) -> anyhow::Result<Vec<EnrollmentRow>>;
+}
+
+/// In-memory [`EnrollmentStore`] — ALWAYS compiled (not `#[cfg(test)]`): this
+/// module's own tests use it, and it is exported so sibling tasks (operator-plane
+/// approve/reject UI, PK-03) can reuse it in their own unit tests without a live
+/// database, exactly like `crate::db::registry::MemRegistryStore`.
+#[derive(Debug, Default)]
+pub struct MemEnrollmentStore {
+    rows: Mutex<HashMap<String, EnrollmentRow>>,
+}
+
+impl MemEnrollmentStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl EnrollmentStore for MemEnrollmentStore {
+    async fn get(&self, spki_fingerprint: &str) -> anyhow::Result<Option<EnrollmentRow>> {
+        Ok(self.rows.lock().unwrap().get(spki_fingerprint).cloned())
+    }
+
+    async fn insert_if_absent(&self, row: EnrollmentRow) -> anyhow::Result<bool> {
+        let mut rows = self.rows.lock().unwrap();
+        if rows.contains_key(&row.spki_fingerprint) {
+            return Ok(false);
+        }
+        rows.insert(row.spki_fingerprint.clone(), row);
+        Ok(true)
+    }
+
+    async fn update(&self, row: EnrollmentRow) -> anyhow::Result<()> {
+        self.rows.lock().unwrap().insert(row.spki_fingerprint.clone(), row);
+        Ok(())
+    }
+
+    async fn list_issued_for_mac(&self, mac: &str) -> anyhow::Result<Vec<EnrollmentRow>> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|r| r.mac.as_deref() == Some(mac) && r.state == EnrollmentState::Issued)
+            .cloned()
+            .collect())
+    }
+}
+
+// ── State machine core ──────────────────────────────────────────────────────────
+
+/// `SubmitCsr` (spec C6): compute the SPKI fingerprint, upsert-if-absent as
+/// `pending`. A known fingerprint is an idempotent upsert — it returns the current
+/// state UNCHANGED, except the renewal rule (see module doc): an `issued` row with
+/// an unexpired cert auto-issues a fresh 90-day cert with no operator round-trip.
+///
+/// Takes `ca`/`audit` in addition to the brief's terse `(store, csr_pem,
+/// claimed_mac, claimed_hostname)` signature: the renewal rule requires actually
+/// signing (needs the CA) and every issuance is an audited mutation (needs the
+/// audit hook) — both explicitly required elsewhere in this same task.
+///
+/// `claimed_hostname` is accepted (matching the `SubmitCsr` wire shape both
+/// transports below use) but deliberately NOT trusted for signing: the
+/// `enrollments` table has no hostname column, and both [`approve`] and the
+/// renewal branch here derive hostname from the CSR's OWN DNS SAN
+/// ([`hostname_from_csr`]) — never from a value supplied alongside a (possibly
+/// already-decided) fingerprint. See the renewal branch below for why.
+pub async fn submit_csr(
+    store: &dyn EnrollmentStore,
+    ca: &InstallCa,
+    audit: &dyn AuditStore,
+    csr_pem: &str,
+    claimed_mac: &str,
+    _claimed_hostname: &str,
+) -> anyhow::Result<EnrollmentRow> {
+    let fp = uaa_core::pki::spki_fingerprint(csr_pem)?;
+
+    let candidate = EnrollmentRow {
+        spki_fingerprint: fp.clone(),
+        mac: Some(claimed_mac.to_string()),
+        csr_pem: csr_pem.to_string(),
+        state: EnrollmentState::Pending,
+        cert_pem: None,
+        requested_at: Some(now_rfc3339()),
+        decided_by: None,
+    };
+
+    if store.insert_if_absent(candidate.clone()).await? {
+        return Ok(candidate);
+    }
+
+    // Known fp: idempotent upsert — NEVER resets a decided row back to pending.
+    let existing = store
+        .get(&fp)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("enrollment row for {fp} vanished after insert_if_absent"))?;
+
+    if existing.state == EnrollmentState::Issued {
+        if let Some(cert_pem) = existing.cert_pem.as_deref() {
+            if cert_is_unexpired(cert_pem)? {
+                // Renewal: same-key CSR against an unexpired (hence unrevoked —
+                // `issued` and `revoked` are mutually exclusive states) cert. Sign
+                // from the STORED row's own mac + the STORED csr's own hostname SAN
+                // — NEVER from `claimed_mac`/`claimed_hostname`/`csr_pem` on this
+                // request. "Same fp" only proves "same public key"; a resubmission
+                // could otherwise carry an attacker-chosen mac/hostname and get an
+                // install-CA-signed cert with NO operator in the loop. This mirrors
+                // exactly what `approve` trusts (the stored row), so the no-operator
+                // auto-issue path can never mint a different identity than the one
+                // an operator already approved for this key.
+                let renewal_mac = existing
+                    .mac
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("issued row {fp} has no mac on file"))?;
+                let renewal_hostname = hostname_from_csr(&existing.csr_pem)?;
+                let fresh_cert_pem =
+                    ca.sign_agent_csr(&existing.csr_pem, &renewal_hostname, &renewal_mac)?;
+                let mut renewed = existing.clone();
+                renewed.cert_pem = Some(fresh_cert_pem);
+                renewed.requested_at = Some(now_rfc3339());
+                store.update(renewed.clone()).await?;
+
+                crate::audit::record(
+                    audit,
+                    "system",
+                    "system",
+                    "enrollment.renew",
+                    Some(fp.clone()),
+                    "success",
+                    Some(json!({"mac": renewal_mac})),
+                )
+                .await?;
+                return Ok(renewed);
+            }
+        }
+    }
+
+    Ok(existing)
+}
+
+/// `GetCredential` (spec C6): a pure read. An UNKNOWN fingerprint returns `Ok(None)`
+/// — the transport layers map this to `404` / `Status::not_found` — NEVER
+/// auto-issuing or auto-creating a row (fail-closed).
+pub async fn get_credential(
+    store: &dyn EnrollmentStore,
+    spki_fingerprint: &str,
+) -> anyhow::Result<Option<EnrollmentRow>> {
+    store.get(spki_fingerprint).await
+}
+
+/// Sign and approve `fp`: sets `issued` + `cert_pem` + `decided_by`. FIRST marks any
+/// OTHER `issued` row for the same claimed MAC `superseded` (reinstalls wipe the
+/// agent state dir and mint a new key — rows must not accrete) — the supersede
+/// mutation, the new `issued` row, AND both audit events all happen before this
+/// returns. May be called on a `rejected`/`revoked` row (that IS the documented
+/// re-approve path — those states are terminal only until an operator acts again).
+///
+/// Hostname is derived from the stored CSR itself (the `enrollments` table has no
+/// separate hostname column — the CSR's own DNS SAN, set by the agent at
+/// `claimed_hostname`, is the source of truth at sign time).
+pub async fn approve(
+    store: &dyn EnrollmentStore,
+    ca: &InstallCa,
+    audit: &dyn AuditStore,
+    fp: &str,
+    decided_by: &str,
+) -> anyhow::Result<EnrollmentRow> {
+    let row = store
+        .get(fp)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("cannot approve unknown spki fingerprint: {fp}"))?;
+    let mac = row
+        .mac
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("enrollment row {fp} has no claimed mac"))?;
+    let hostname = hostname_from_csr(&row.csr_pem)?;
+
+    let cert_pem = ca.sign_agent_csr(&row.csr_pem, &hostname, &mac)?;
+
+    // Supersede FIRST — before the new row is marked issued.
+    for other in store.list_issued_for_mac(&mac).await? {
+        if other.spki_fingerprint == fp {
+            continue;
+        }
+        let other_fp = other.spki_fingerprint.clone();
+        let mut superseded = other;
+        superseded.state = EnrollmentState::Superseded;
+        store.update(superseded).await?;
+        crate::audit::record(
+            audit,
+            decided_by,
+            "operator",
+            "enrollment.supersede",
+            Some(other_fp),
+            "success",
+            Some(json!({"mac": mac, "superseded_by": fp})),
+        )
+        .await?;
+    }
+
+    let mut issued = row;
+    issued.state = EnrollmentState::Issued;
+    issued.cert_pem = Some(cert_pem);
+    issued.decided_by = Some(decided_by.to_string());
+    store.update(issued.clone()).await?;
+
+    crate::audit::record(
+        audit,
+        decided_by,
+        "operator",
+        "enrollment.approve",
+        Some(fp.to_string()),
+        "success",
+        Some(json!({"mac": mac, "hostname": hostname})),
+    )
+    .await?;
+
+    Ok(issued)
+}
+
+/// Reject `fp`: a terminal state until an operator explicitly re-[`approve`]s it.
+pub async fn reject(
+    store: &dyn EnrollmentStore,
+    audit: &dyn AuditStore,
+    fp: &str,
+    decided_by: &str,
+) -> anyhow::Result<EnrollmentRow> {
+    let mut row = store
+        .get(fp)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("cannot reject unknown spki fingerprint: {fp}"))?;
+    row.state = EnrollmentState::Rejected;
+    row.decided_by = Some(decided_by.to_string());
+    store.update(row.clone()).await?;
+
+    crate::audit::record(
+        audit,
+        decided_by,
+        "operator",
+        "enrollment.reject",
+        Some(fp.to_string()),
+        "success",
+        None,
+    )
+    .await?;
+
+    Ok(row)
+}
+
+/// Revoke `fp`: a terminal state until an operator explicitly re-[`approve`]s it.
+/// Revocation is recorded as an audit event ONLY here — PK-03 hooks its
+/// `regenerate_crl` (spec Decision 25) onto this same audited mutation; CRL
+/// generation itself is explicitly out of scope for this task.
+pub async fn revoke(
+    store: &dyn EnrollmentStore,
+    audit: &dyn AuditStore,
+    fp: &str,
+    decided_by: &str,
+) -> anyhow::Result<EnrollmentRow> {
+    let mut row = store
+        .get(fp)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("cannot revoke unknown spki fingerprint: {fp}"))?;
+    row.state = EnrollmentState::Revoked;
+    row.decided_by = Some(decided_by.to_string());
+    store.update(row.clone()).await?;
+
+    crate::audit::record(
+        audit,
+        decided_by,
+        "operator",
+        "enrollment.revoke",
+        Some(fp.to_string()),
+        "success",
+        None,
+    )
+    .await?;
+
+    Ok(row)
+}
+
+/// Extracts the DNS SAN (the agent-claimed hostname) from a stored CSR — the
+/// `enrollments` table has no separate hostname column, so the CSR itself is the
+/// source of truth at sign time (see [`approve`]).
+fn hostname_from_csr(csr_pem: &str) -> anyhow::Result<String> {
+    let params = rcgen::CertificateSigningRequestParams::from_pem(csr_pem)
+        .map_err(|e| anyhow::anyhow!("invalid CSR: {e}"))?
+        .params;
+    params
+        .subject_alt_names
+        .into_iter()
+        .find_map(|san| match san {
+            rcgen::SanType::DnsName(dns) => Some(dns.to_string()),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow::anyhow!("CSR has no DNS SAN (hostname) to sign"))
+}
+
+/// `true` iff `cert_pem` parses and its `not_after` is still in the future. An
+/// `issued` row is by construction not revoked (revocation transitions the row to
+/// the separate `revoked` state), so this single check covers the renewal rule's
+/// "unexpired+unrevoked" clause for an `issued` row.
+fn cert_is_unexpired(cert_pem: &str) -> anyhow::Result<bool> {
+    let (_, pem) = x509_parser::pem::parse_x509_pem(cert_pem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid cert PEM: {e:?}"))?;
+    let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)
+        .map_err(|e| anyhow::anyhow!("invalid cert DER: {e:?}"))?;
+    let now = x509_parser::time::ASN1Time::now().timestamp();
+    Ok(now < cert.validity().not_after.timestamp())
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+// ── gRPC service surface (uaa.enroll.v1.EnrollService, CP-02 types) ──────────────
+
+/// Tonic server impl of `uaa.enroll.v1.EnrollService` — delegates to the state
+/// machine core above. Exposed as `pub` so the coordinator constructs it (with the
+/// real [`MemEnrollmentStore`]-or-`Pg` store, [`InstallCa`], and audit store) and
+/// wires it wherever the real gRPC transport lands (spec: TLS termination for
+/// `:7443` arrives with PK-03/CT-07 — see `crate::listeners` module doc).
+pub struct EnrollGrpcService {
+    store: Arc<dyn EnrollmentStore>,
+    ca: Arc<InstallCa>,
+    audit: Arc<dyn AuditStore>,
+}
+
+impl EnrollGrpcService {
+    pub fn new(store: Arc<dyn EnrollmentStore>, ca: Arc<InstallCa>, audit: Arc<dyn AuditStore>) -> Self {
+        Self { store, ca, audit }
+    }
+}
+
+#[tonic::async_trait]
+impl uaa_proto::enroll::v1::enroll_service_server::EnrollService for EnrollGrpcService {
+    async fn submit_csr(
+        &self,
+        request: tonic::Request<uaa_proto::enroll::v1::SubmitCsrRequest>,
+    ) -> Result<tonic::Response<uaa_proto::enroll::v1::SubmitCsrResponse>, tonic::Status> {
+        let req = request.into_inner();
+        let row = submit_csr(
+            self.store.as_ref(),
+            self.ca.as_ref(),
+            self.audit.as_ref(),
+            &req.csr_pem,
+            &req.claimed_mac,
+            &req.claimed_hostname,
+        )
+        .await
+        .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
+
+        Ok(tonic::Response::new(uaa_proto::enroll::v1::SubmitCsrResponse {
+            spki_fingerprint: row.spki_fingerprint,
+            state: String::from(row.state),
+        }))
+    }
+
+    async fn get_credential(
+        &self,
+        request: tonic::Request<uaa_proto::enroll::v1::GetCredentialRequest>,
+    ) -> Result<tonic::Response<uaa_proto::enroll::v1::GetCredentialResponse>, tonic::Status> {
+        let req = request.into_inner();
+        match get_credential(self.store.as_ref(), &req.spki_fingerprint).await {
+            Ok(Some(row)) => {
+                let issued = row.state == EnrollmentState::Issued;
+                Ok(tonic::Response::new(uaa_proto::enroll::v1::GetCredentialResponse {
+                    state: String::from(row.state),
+                    cert_pem: row.cert_pem.unwrap_or_default(),
+                    ca_pem: if issued {
+                        self.ca.ca_cert_pem().to_string()
+                    } else {
+                        String::new()
+                    },
+                }))
+            }
+            // Fail-closed: unknown fingerprint -> NOT_FOUND, never auto-issued.
+            Ok(None) => Err(tonic::Status::not_found(format!(
+                "unknown spki fingerprint: {}",
+                req.spki_fingerprint
+            ))),
+            Err(e) => Err(tonic::Status::internal(e.to_string())),
+        }
+    }
+}
+
+/// Build the tonic server wrapper for [`EnrollGrpcService`] — the coordinator's one
+/// call site to add it to a `tonic::transport::Server` once the real `:7443` gRPC
+/// transport lands (PK-03/CT-07).
+pub fn enroll_grpc_service(
+    store: Arc<dyn EnrollmentStore>,
+    ca: Arc<InstallCa>,
+    audit: Arc<dyn AuditStore>,
+) -> uaa_proto::enroll::v1::enroll_service_server::EnrollServiceServer<EnrollGrpcService> {
+    uaa_proto::enroll::v1::enroll_service_server::EnrollServiceServer::new(EnrollGrpcService::new(
+        store, ca, audit,
+    ))
+}
+
+// ── `:7444` JSON mirror (POST /enroll/csr, GET /enroll/credential/<fp>) ──────────
+
+/// Request body for `POST /enroll/csr` — field-for-field the wire shape
+/// `uaa_core::pki::SubmitCsrRequest` (the agent client, PK-02) serializes.
+#[derive(Debug, Deserialize)]
+struct SubmitCsrBody {
+    csr_pem: String,
+    claimed_hostname: String,
+    claimed_mac: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SubmitCsrResponseBody {
+    spki_fingerprint: String,
+    state: String,
+}
+
+/// Response body for `GET /enroll/credential/<fp>` (200 case) — field-for-field the
+/// wire shape `uaa_core::pki::GetCredentialResponse` (PK-02) deserializes.
+#[derive(Debug, Serialize, Default)]
+struct GetCredentialResponseBody {
+    state: String,
+    cert_pem: String,
+    ca_pem: String,
+}
+
+#[derive(Clone)]
+struct AppState {
+    store: Arc<dyn EnrollmentStore>,
+    ca: Arc<InstallCa>,
+    audit: Arc<dyn AuditStore>,
+}
+
+/// The `:7444` enrollment JSON router — `POST /enroll/csr`, `GET
+/// /enroll/credential/:fp`. Built by the coordinator with the real store/CA/audit
+/// instances and merged into the `:7444` listener wiring point in
+/// `crate::listeners` (see that module's doc — never edited by this task).
+pub fn enroll_json_router(
+    store: Arc<dyn EnrollmentStore>,
+    ca: Arc<InstallCa>,
+    audit: Arc<dyn AuditStore>,
+) -> Router {
+    Router::new()
+        .route("/enroll/csr", post(handle_submit_csr))
+        .route("/enroll/credential/:fp", get(handle_get_credential))
+        .with_state(AppState { store, ca, audit })
+}
+
+async fn handle_submit_csr(State(state): State<AppState>, Json(body): Json<SubmitCsrBody>) -> Response {
+    match submit_csr(
+        state.store.as_ref(),
+        state.ca.as_ref(),
+        state.audit.as_ref(),
+        &body.csr_pem,
+        &body.claimed_mac,
+        &body.claimed_hostname,
+    )
+    .await
+    {
+        Ok(row) => Json(SubmitCsrResponseBody {
+            spki_fingerprint: row.spki_fingerprint,
+            state: String::from(row.state),
+        })
+        .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+async fn handle_get_credential(State(state): State<AppState>, AxumPath(fp): AxumPath<String>) -> Response {
+    match get_credential(state.store.as_ref(), &fp).await {
+        Ok(Some(row)) => {
+            let issued = row.state == EnrollmentState::Issued;
+            Json(GetCredentialResponseBody {
+                state: String::from(row.state),
+                cert_pem: row.cert_pem.unwrap_or_default(),
+                ca_pem: if issued {
+                    state.ca.ca_cert_pem().to_string()
+                } else {
+                    String::new()
+                },
+            })
+            .into_response()
+        }
+        // Fail-closed: unknown fingerprint -> 404, never auto-issued.
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "unknown spki fingerprint"})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::MemAuditStore;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tempfile::tempdir;
+    use tower::ServiceExt;
+    use uaa_core::pki::{generate_keypair_and_csr, AgentIdentity};
+
+    fn test_ca() -> InstallCa {
+        let dir = tempdir().unwrap();
+        InstallCa::load_or_create(&dir.path().join("ca")).unwrap()
+    }
+
+    fn identity(hostname: &str, mac: &str) -> AgentIdentity {
+        AgentIdentity {
+            hostname: hostname.to_string(),
+            mac: mac.to_string(),
+        }
+    }
+
+    fn csr_for(id: &AgentIdentity) -> String {
+        generate_keypair_and_csr(id).unwrap().1
+    }
+
+    // ── submit_csr ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_submit_csr_idempotent_reclaim() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("host1", "aa:bb:cc:dd:ee:01");
+        let csr_pem = csr_for(&id);
+
+        let first = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        assert_eq!(first.state, EnrollmentState::Pending);
+
+        let second = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        assert_eq!(second.state, EnrollmentState::Pending);
+        assert_eq!(second.spki_fingerprint, first.spki_fingerprint);
+
+        // Exactly one row for this fp — the second submit must not have appended.
+        assert!(store.get(&first.spki_fingerprint).await.unwrap().is_some());
+    }
+
+    // ── fail-closed 404 ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_unknown_fp_get_credential_404() {
+        let store = MemEnrollmentStore::new();
+        let result = get_credential(&store, "deadbeef-unknown-fp").await.unwrap();
+        assert!(result.is_none(), "unknown fp must never auto-issue — Ok(None)");
+    }
+
+    #[tokio::test]
+    async fn test_unknown_fp_json_returns_404() {
+        let store: Arc<dyn EnrollmentStore> = Arc::new(MemEnrollmentStore::new());
+        let ca = Arc::new(test_ca());
+        let audit: Arc<dyn AuditStore> = Arc::new(MemAuditStore::new());
+        let router = enroll_json_router(store, ca, audit);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/enroll/credential/unknown-fp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── approve / SAN / lifetime ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_approve_signs_90d_san() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("host2", "aa:bb:cc:dd:ee:02");
+        let csr_pem = csr_for(&id);
+
+        let submitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        let issued = approve(&store, &ca, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+
+        assert_eq!(issued.state, EnrollmentState::Issued);
+        let cert_pem = issued.cert_pem.expect("cert_pem set on issue");
+
+        let (_, pem) = x509_parser::pem::parse_x509_pem(cert_pem.as_bytes()).unwrap();
+        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents).unwrap();
+        let validity = cert.validity();
+        let lifetime_days =
+            (validity.not_after.timestamp() - validity.not_before.timestamp()) / 86_400;
+        assert!((89..=91).contains(&lifetime_days), "expected ~90d, got {lifetime_days}d");
+
+        let mut found_dns = false;
+        let mut found_uri = false;
+        for ext in cert.extensions() {
+            if let x509_parser::extensions::ParsedExtension::SubjectAlternativeName(san) =
+                ext.parsed_extension()
+            {
+                for name in &san.general_names {
+                    match name {
+                        x509_parser::extensions::GeneralName::DNSName(dns) if *dns == id.hostname => {
+                            found_dns = true
+                        }
+                        x509_parser::extensions::GeneralName::URI(uri)
+                            if *uri == format!("uaa-mac:{}", id.mac) =>
+                        {
+                            found_uri = true
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(found_dns && found_uri, "SAN must be hostname (DNS) + uaa-mac:<mac> (URI)");
+    }
+
+    // ── anti-over-suppression ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_approved_fp_still_issued_happy_path() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("host3", "aa:bb:cc:dd:ee:03");
+        let csr_pem = csr_for(&id);
+
+        let submitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        approve(&store, &ca, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+
+        let polled = get_credential(&store, &submitted.spki_fingerprint)
+            .await
+            .unwrap()
+            .expect("known fp must be found");
+        assert_eq!(polled.state, EnrollmentState::Issued);
+        assert!(polled.cert_pem.is_some(), "issued poll must return the signed cert");
+    }
+
+    // ── supersede-on-reinstall ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_supersede_on_reinstall() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let mac = "aa:bb:cc:dd:ee:04";
+
+        // First install: submit + approve -> issued.
+        let id1 = identity("host4", mac);
+        let csr1 = csr_for(&id1);
+        let first = submit_csr(&store, &ca, &audit, &csr1, mac, &id1.hostname)
+            .await
+            .unwrap();
+        let first_issued = approve(&store, &ca, &audit, &first.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+        assert_eq!(first_issued.state, EnrollmentState::Issued);
+
+        // Reinstall: state dir wiped, agent mints a NEW keypair -> a NEW fp for the
+        // SAME mac.
+        let id2 = identity("host4", mac);
+        let csr2 = csr_for(&id2);
+        let second = submit_csr(&store, &ca, &audit, &csr2, mac, &id2.hostname)
+            .await
+            .unwrap();
+        assert_ne!(second.spki_fingerprint, first.spki_fingerprint, "reinstall mints a new keypair");
+
+        let second_issued = approve(&store, &ca, &audit, &second.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+        assert_eq!(second_issued.state, EnrollmentState::Issued);
+
+        let old_row = store.get(&first.spki_fingerprint).await.unwrap().unwrap();
+        assert_eq!(
+            old_row.state,
+            EnrollmentState::Superseded,
+            "approving the new fp must supersede the old issued row"
+        );
+
+        let new_row = store.get(&second.spki_fingerprint).await.unwrap().unwrap();
+        assert_eq!(new_row.state, EnrollmentState::Issued);
+    }
+
+    // ── renewal (same-key auto-issue) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_renewal_same_key_auto_issue() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("host5", "aa:bb:cc:dd:ee:05");
+        let csr_pem = csr_for(&id);
+
+        let submitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        let first_issued = approve(&store, &ca, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+        let first_cert = first_issued.cert_pem.clone().unwrap();
+
+        // Same-key CSR resubmitted (agent renewal at 2/3 lifetime) — no operator
+        // round-trip: submit_csr alone must auto-issue a FRESH cert.
+        let renewed = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        assert_eq!(renewed.state, EnrollmentState::Issued);
+        assert_eq!(renewed.spki_fingerprint, submitted.spki_fingerprint);
+        assert_ne!(
+            renewed.cert_pem.unwrap(),
+            first_cert,
+            "renewal must mint a FRESH cert, not return the old one"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_renewal_ignores_spoofed_claim_on_resubmit() {
+        // Security regression: a same-key resubmission with a DIFFERENT claimed
+        // mac/hostname must NOT get those attacker-controlled values signed onto
+        // the fresh cert with no operator in the loop. "Same fp" only proves "same
+        // public key" — the renewal path must sign from the STORED row's mac and
+        // the STORED csr's own hostname SAN, exactly like `approve` does.
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("realhost", "aa:bb:cc:dd:ee:09");
+        let csr_pem = csr_for(&id);
+
+        let submitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        approve(&store, &ca, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+
+        // Same CSR bytes (same key, same fp), but the request now claims a
+        // DIFFERENT mac/hostname — must be ignored by the auto-issue path.
+        let renewed = submit_csr(
+            &store,
+            &ca,
+            &audit,
+            &csr_pem,
+            "ff:ff:ff:ff:ff:ff",
+            "attacker-claimed-host",
+        )
+        .await
+        .unwrap();
+        assert_eq!(renewed.state, EnrollmentState::Issued);
+        let cert_pem = renewed.cert_pem.unwrap();
+
+        let (_, pem) = x509_parser::pem::parse_x509_pem(cert_pem.as_bytes()).unwrap();
+        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents).unwrap();
+        let mut saw_spoofed_host = false;
+        let mut saw_spoofed_mac = false;
+        let mut saw_real_host = false;
+        for ext in cert.extensions() {
+            if let x509_parser::extensions::ParsedExtension::SubjectAlternativeName(san) =
+                ext.parsed_extension()
+            {
+                for name in &san.general_names {
+                    match name {
+                        x509_parser::extensions::GeneralName::DNSName(dns) => {
+                            if *dns == "attacker-claimed-host" {
+                                saw_spoofed_host = true;
+                            }
+                            if *dns == id.hostname {
+                                saw_real_host = true;
+                            }
+                        }
+                        x509_parser::extensions::GeneralName::URI(uri) => {
+                            if *uri == "uaa-mac:ff:ff:ff:ff:ff:ff" {
+                                saw_spoofed_mac = true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(!saw_spoofed_host, "renewal must never sign the resubmitted hostname claim");
+        assert!(!saw_spoofed_mac, "renewal must never sign the resubmitted mac claim");
+        assert!(saw_real_host, "renewal must keep signing the ORIGINAL approved hostname");
+        // Row's mac on file must also be untouched by the spoofed resubmission.
+        assert_eq!(renewed.mac.as_deref(), Some(id.mac.as_str()));
+    }
+
+    #[tokio::test]
+    async fn test_renewal_refused_when_revoked() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("host6", "aa:bb:cc:dd:ee:06");
+        let csr_pem = csr_for(&id);
+
+        let submitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        approve(&store, &ca, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+        let revoked = revoke(&store, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+        assert_eq!(revoked.state, EnrollmentState::Revoked);
+
+        // Same-key CSR after revoke: submit_csr must NOT auto-issue.
+        let after = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        assert_eq!(after.state, EnrollmentState::Revoked, "revoked must stay revoked, no auto-issue");
+    }
+
+    // ── rejected holds until re-approve ───────────────────────────────────
+
+    #[tokio::test]
+    async fn test_rejected_holds_until_reapprove() {
+        let store = MemEnrollmentStore::new();
+        let ca = test_ca();
+        let audit = MemAuditStore::new();
+        let id = identity("host7", "aa:bb:cc:dd:ee:07");
+        let csr_pem = csr_for(&id);
+
+        let submitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        let rejected = reject(&store, &audit, &submitted.spki_fingerprint, "alice")
+            .await
+            .unwrap();
+        assert_eq!(rejected.state, EnrollmentState::Rejected);
+
+        // Holds: a poll (and even a resubmit) must not move it off `rejected`.
+        let polled = get_credential(&store, &submitted.spki_fingerprint)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(polled.state, EnrollmentState::Rejected);
+        let resubmitted = submit_csr(&store, &ca, &audit, &csr_pem, &id.mac, &id.hostname)
+            .await
+            .unwrap();
+        assert_eq!(resubmitted.state, EnrollmentState::Rejected, "resubmit must not clear rejected");
+
+        // Operator re-approves: rejected -> issued.
+        let issued = approve(&store, &ca, &audit, &submitted.spki_fingerprint, "bob")
+            .await
+            .unwrap();
+        assert_eq!(issued.state, EnrollmentState::Issued);
+    }
+
+    // ── CA custody boundary ───────────────────────────────────────────────
+
+    #[test]
+    fn test_no_second_trust_root_referenced_in_this_module() {
+        // The whole point of Decision 6: this module never names a second CA. A
+        // grep-based acceptance check backs this at the repo level; this test pins
+        // the same property at the type level (the only signer type in scope is
+        // `crate::ca::InstallCa`).
+        fn assert_signer_is_install_ca(_ca: &InstallCa) {}
+        let ca = test_ca();
+        assert_signer_is_install_ca(&ca);
+    }
+
+    // ── gRPC surface ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_grpc_submit_then_get_credential_not_found() {
+        use uaa_proto::enroll::v1::enroll_service_server::EnrollService as _;
+        use uaa_proto::enroll::v1::{GetCredentialRequest, SubmitCsrRequest};
+
+        let store: Arc<dyn EnrollmentStore> = Arc::new(MemEnrollmentStore::new());
+        let ca = Arc::new(test_ca());
+        let audit: Arc<dyn AuditStore> = Arc::new(MemAuditStore::new());
+        let svc = EnrollGrpcService::new(store, ca, audit);
+
+        let unknown = svc
+            .get_credential(tonic::Request::new(GetCredentialRequest {
+                spki_fingerprint: "unknown".to_string(),
+            }))
+            .await;
+        assert_eq!(unknown.unwrap_err().code(), tonic::Code::NotFound);
+
+        let id = identity("host8", "aa:bb:cc:dd:ee:08");
+        let csr_pem = csr_for(&id);
+        let resp = svc
+            .submit_csr(tonic::Request::new(SubmitCsrRequest {
+                csr_pem,
+                claimed_hostname: id.hostname.clone(),
+                claimed_mac: id.mac.clone(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.state, "pending");
+    }
+}

--- a/crates/uaa-control/src/listeners.rs
+++ b/crates/uaa-control/src/listeners.rs
@@ -112,7 +112,15 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     let operator = bind(config.operator_port).await?;
 
     let machine = tokio::spawn(async move {
-        axum::serve(machine_listener, crate::machine_plane::router()).await
+        // ConnectInfo::<SocketAddr> is required: the /autoinstall/* seed handlers
+        // (IP-01) read the client's TCP peer address for `ip neigh` MAC resolution
+        // (Python parity). Without into_make_service_with_connect_info they 500.
+        axum::serve(
+            machine_listener,
+            crate::machine_plane::router()
+                .into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
     });
     let grpc = tokio::spawn(async move { axum::serve(grpc, health_router("grpc")).await });
     let enroll = tokio::spawn(async move { axum::serve(enroll, health_router("enroll")).await });

--- a/crates/uaa-control/src/machine_plane/inventory.rs
+++ b/crates/uaa-control/src/machine_plane/inventory.rs
@@ -1,9 +1,1619 @@
 // file: crates/uaa-control/src/machine_plane/inventory.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 76633c84-b337-47da-ab77-11cbf0f4b3b5
 // last-edited: 2026-07-10
 
-//! Machine-plane inventory listing + discovery inbox (:25000 parity).
+//! Machine-plane operator/inventory endpoints (`:25000` parity, spec Decision 12).
 //!
-//! STUB — Filled exclusively by install-plane IP-03. Adds `pub fn router()`, then
-//! merges it into `machine_plane::router()` with one line.
+//! Exact parity with `scripts/autoinstall-agent.py` for: `/api/certs/<hostname>`,
+//! `/api/flip/<hostname>`, `/api/approve/<mac>`, `/api/deregister/<mac>`,
+//! `/api/registry`, `/api/events`, the six `/api/yubikeys*` routes, the two
+//! `/api/tang*` routes, and the machine-plane catch-all `404 {"error":"not
+//! found"}` (Python `:558,711`).
+//!
+//! # Coordinator wiring (read before touching any other file)
+//!
+//! This module is purely additive and self-contained (install-plane IP-03; the
+//! CT-01 stub this fills). `crate::db::registry::RegistryStore` (CT-02) has no
+//! method to delete a machine row or to set a yubikey's `approved_at`/`revoked_at`
+//! (the `yubikeys` table — `migrations/0001_init.sql` — has no such columns), so
+//! this module follows the same wave-4 de-collision pattern `reinstall.rs` (CT-06)
+//! documents: it declares its own narrow local [`Registry`] seam instead of
+//! blocking on / bending a shared trait it cannot edit.
+//!   * Machines route through `crate::db::store` ([`read_snapshot`]/
+//!     [`write_snapshot`]/[`StatePaths`]) — the SAME on-disk snapshot
+//!     `machine_plane::lifecycle` (IP-02) reads and writes, so a machine
+//!     registered via `/api/register` is immediately visible to `/api/approve`,
+//!     `/api/deregister`, `/api/certs`, and `/api/flip` here.
+//!   * YubiKeys/tang/events are legacy standalone JSON stores, exactly mirroring
+//!     Python's own `YUBIKEY_REGISTRY_FILE`/`TANG_REGISTRY_FILE`/`EVENTS_LOG`
+//!     (`scripts/autoinstall-agent.py` `:37-39`) — NOT the CT-01 `SnapshotDoc`
+//!     fields of the same name. `YubikeyRow` (`db::mod`) cannot carry
+//!     `approved_at`/`revoked_at` without a migration change (out of scope: a
+//!     single-file task cannot touch `db/mod.rs`), so this module keeps its own
+//!     [`YubikeyEntry`] shape instead. TODO(coordinator): once CT-02's schema
+//!     grows `approved_at`/`revoked_at` columns, unify onto `RegistryStore`.
+//!
+//! `cockroach cert create-node` is shelled out ONLY through the
+//! [`uaa_core::network::CommandExecutor`] seam — never a raw std-library process
+//! spawn directly — production wires [`LocalClient`]; tests inject a mock that
+//! writes fake `node.crt`/`node.key` into the certs-dir it is pointed at.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::{Path as AxumPath, Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use uaa_core::network::{CommandExecutor, LocalClient};
+
+use crate::db::{
+    store::{read_snapshot, write_snapshot, StatePaths},
+    MachineRow, MachineStatus, TangServerRow,
+};
+
+use super::lifecycle::{flip_ipxe_content, normalize_mac};
+
+/// Default iPXE boot-menu directory (mirrors Python's `IPXE_BOOT_DIR`, `:31`).
+const IPXE_BOOT_DIR: &str = "/var/www/html/ipxe/boot";
+/// Legacy YubiKey registry file (mirrors Python's `YUBIKEY_REGISTRY_FILE`, `:38`).
+const YUBIKEY_REGISTRY_FILE: &str = "/var/log/cockroach-autoinstall/yubikey-registry.json";
+/// Legacy tang-server registry file (mirrors Python's `TANG_REGISTRY_FILE`, `:39`).
+const TANG_REGISTRY_FILE: &str = "/var/log/cockroach-autoinstall/tang-registry.json";
+/// Legacy events log (mirrors Python's `EVENTS_LOG`, `:35`).
+const EVENTS_LOG: &str = "/var/log/cockroach-autoinstall/events.jsonl";
+/// CockroachDB node-cert CA (parity-frozen legacy — NOT the install CA of spec
+/// Decision 6; Python `:41`). Serves node-cert issuance for the DB cluster only.
+const COCKROACH_CA_CRT: &str = "/var/lib/cockroach-autoinstall/.cockroach-ca/ca.crt";
+/// CockroachDB node-cert CA key (Python `:42`).
+const COCKROACH_CA_KEY: &str = "/var/lib/cockroach-autoinstall/.cockroach-ca/ca.key";
+
+// ── YubiKey entry (own shape — see module doc) ───────────────────────────────
+
+/// A registered YubiKey. Own shape (not [`crate::db::YubikeyRow`]) because the
+/// `yubikeys` table has no `approved_at`/`revoked_at` columns; see module doc.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct YubikeyEntry {
+    pub fingerprint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpg_pubkey: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_pubkey: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial: Option<String>,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registered_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<i64>,
+}
+
+impl YubikeyEntry {
+    /// The listing/approve-echo view: identical to the full row minus
+    /// `gpg_pubkey` (Python `:422`, `:445` — never leak the raw key blob).
+    fn without_gpg_pubkey(&self) -> Value {
+        let mut v = serde_json::to_value(self).unwrap_or_else(|_| json!({}));
+        if let Some(obj) = v.as_object_mut() {
+            obj.remove("gpg_pubkey");
+        }
+        v
+    }
+}
+
+// ── Registry seam (mockable; no direct DB/process access) ───────────────────
+
+/// Persistence seam for the inventory handlers — see the module-level
+/// coordinator-wiring note for why this is a local trait rather than
+/// `crate::db::registry::RegistryStore`.
+#[async_trait::async_trait]
+pub trait Registry: Send + Sync {
+    /// Look up a machine row by normalized MAC.
+    async fn get_machine(&self, mac: &str) -> Option<MachineRow>;
+    /// Look up a machine row by hostname (first match; mirrors Python's
+    /// linear `for e in reg.values()` scans, `:295`, `:321`).
+    async fn find_machine_by_hostname(&self, hostname: &str) -> Option<MachineRow>;
+    /// The whole machine registry (Python `:401-403`).
+    async fn list_machines(&self) -> Vec<MachineRow>;
+    /// Set `status=approved` + `approved_at`; returns the updated row, or
+    /// `None` if `mac` is not registered.
+    async fn approve_machine(&self, mac: &str, approved_at: String) -> Option<MachineRow>;
+    /// Remove the row for `mac` and return it (for the hostname in the
+    /// deregister message), or `None` if `mac` was not registered.
+    async fn delete_machine(&self, mac: &str) -> Option<MachineRow>;
+    /// Last `limit` events, oldest-first. ANY read/parse error yields an EMPTY
+    /// vec (Python `:406-412` wraps the whole read in a bare `except`, never a
+    /// 500 — Decision 12 collections-vs-single-resources convention).
+    async fn list_events(&self, limit: usize) -> Vec<Value>;
+    /// All registered YubiKeys, keyed by fingerprint.
+    async fn list_yubikeys(&self) -> Vec<YubikeyEntry>;
+    /// A single YubiKey by (already-uppercased) fingerprint.
+    async fn get_yubikey(&self, fingerprint: &str) -> Option<YubikeyEntry>;
+    /// Set `status=approved` + `approved_at`; `None` if unknown.
+    async fn approve_yubikey(&self, fingerprint: &str, at: i64) -> Option<YubikeyEntry>;
+    /// Set `status=revoked` + `revoked_at`; `None` if unknown.
+    async fn revoke_yubikey(&self, fingerprint: &str, at: i64) -> Option<YubikeyEntry>;
+    /// Upsert from `POST /api/yubikeys/register`: `status`/`registered_at` are
+    /// PRESERVED from any existing row (default pending/now); every other
+    /// field — including `approved_at`/`revoked_at` — is reset, mirroring
+    /// Python's full-dict-literal replace (`:676-684`).
+    async fn upsert_yubikey_register(&self, entry: YubikeyEntry) -> YubikeyEntry;
+    /// The whole tang-server registry (Python `:487-490`).
+    async fn list_tang(&self) -> Vec<TangServerRow>;
+    /// Full-replace upsert keyed by hostname (Python `tang[hostname] = {...}`,
+    /// `:699` — real last-seen-wins overwrite, not insert-if-absent).
+    async fn upsert_tang(&self, row: TangServerRow);
+}
+
+/// Real [`Registry`]: machines via CT-01's snapshot (shared with
+/// `machine_plane::lifecycle`); yubikeys/tang/events via their own legacy JSON
+/// files (see module doc for why these are not the `SnapshotDoc` fields of the
+/// same name).
+pub struct FileRegistry {
+    machine_paths: StatePaths,
+    yubikey_file: PathBuf,
+    tang_file: PathBuf,
+    events_file: PathBuf,
+}
+
+impl FileRegistry {
+    pub fn new(
+        machine_paths: StatePaths,
+        yubikey_file: PathBuf,
+        tang_file: PathBuf,
+        events_file: PathBuf,
+    ) -> Self {
+        Self {
+            machine_paths,
+            yubikey_file,
+            tang_file,
+            events_file,
+        }
+    }
+
+    fn load_yubikeys(&self) -> HashMap<String, YubikeyEntry> {
+        load_json_map(&self.yubikey_file)
+    }
+
+    fn save_yubikeys(&self, map: &HashMap<String, YubikeyEntry>) {
+        save_json_map(&self.yubikey_file, map);
+    }
+
+    fn load_tang(&self) -> HashMap<String, TangServerRow> {
+        load_json_map(&self.tang_file)
+    }
+
+    fn save_tang(&self, map: &HashMap<String, TangServerRow>) {
+        save_json_map(&self.tang_file, map);
+    }
+}
+
+/// Load a `HashMap<String, T>` from a JSON file. A missing OR corrupt file
+/// yields an EMPTY map (never a panic) — mirrors Python's `load_*_registry`
+/// bare `except: return {}` (`:62-65`, `:79-83`, `:91-95`).
+fn load_json_map<T: serde::de::DeserializeOwned>(path: &Path) -> HashMap<String, T> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+/// Atomically persist a `HashMap<String, T>` to a JSON file: tmp write + rename
+/// (mirrors Python's `save_*_registry` tmp+`os.replace` idiom, `:67-70`).
+fn save_json_map<T: Serialize>(path: &Path, map: &HashMap<String, T>) {
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            tracing::error!(%err, path = %parent.display(), "failed to create registry dir");
+            return;
+        }
+    }
+    let bytes = match serde_json::to_vec_pretty(map) {
+        Ok(b) => b,
+        Err(err) => {
+            tracing::error!(%err, "failed to serialize registry");
+            return;
+        }
+    };
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    if let Err(err) = std::fs::write(&tmp, &bytes) {
+        tracing::error!(%err, path = %tmp.display(), "failed to write registry tmp file");
+        return;
+    }
+    if let Err(err) = std::fs::rename(&tmp, path) {
+        tracing::error!(%err, path = %path.display(), "failed to rename registry tmp file into place");
+    }
+}
+
+#[async_trait::async_trait]
+impl Registry for FileRegistry {
+    async fn get_machine(&self, mac: &str) -> Option<MachineRow> {
+        let doc = read_snapshot(&self.machine_paths);
+        doc.machines.into_iter().find(|m| m.mac == mac)
+    }
+
+    async fn find_machine_by_hostname(&self, hostname: &str) -> Option<MachineRow> {
+        let doc = read_snapshot(&self.machine_paths);
+        doc.machines.into_iter().find(|m| m.hostname == hostname)
+    }
+
+    async fn list_machines(&self) -> Vec<MachineRow> {
+        read_snapshot(&self.machine_paths).machines
+    }
+
+    async fn approve_machine(&self, mac: &str, approved_at: String) -> Option<MachineRow> {
+        let mut doc = read_snapshot(&self.machine_paths);
+        let row = doc.machines.iter_mut().find(|m| m.mac == mac)?;
+        row.status = MachineStatus::Approved;
+        row.approved_at = Some(approved_at);
+        let updated = row.clone();
+        if let Err(err) = write_snapshot(&self.machine_paths, &doc) {
+            tracing::error!(%err, "failed to persist machine approval");
+        }
+        Some(updated)
+    }
+
+    async fn delete_machine(&self, mac: &str) -> Option<MachineRow> {
+        let mut doc = read_snapshot(&self.machine_paths);
+        let idx = doc.machines.iter().position(|m| m.mac == mac)?;
+        let removed = doc.machines.remove(idx);
+        if let Err(err) = write_snapshot(&self.machine_paths, &doc) {
+            tracing::error!(%err, "failed to persist machine deregistration");
+        }
+        Some(removed)
+    }
+
+    async fn list_events(&self, limit: usize) -> Vec<Value> {
+        let content = match std::fs::read_to_string(&self.events_file) {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+        let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+        let start = lines.len().saturating_sub(limit);
+        let mut out = Vec::with_capacity(lines.len() - start);
+        for line in &lines[start..] {
+            match serde_json::from_str::<Value>(line) {
+                Ok(v) => out.push(v),
+                // Python's `[json.loads(l) for l in lines]` raises on the first
+                // bad line and the outer `except` swallows it into `[]` — a
+                // single corrupt line zeroes the whole window, not just itself.
+                Err(_) => return Vec::new(),
+            }
+        }
+        out
+    }
+
+    async fn list_yubikeys(&self) -> Vec<YubikeyEntry> {
+        self.load_yubikeys().into_values().collect()
+    }
+
+    async fn get_yubikey(&self, fingerprint: &str) -> Option<YubikeyEntry> {
+        self.load_yubikeys().get(fingerprint).cloned()
+    }
+
+    async fn approve_yubikey(&self, fingerprint: &str, at: i64) -> Option<YubikeyEntry> {
+        let mut map = self.load_yubikeys();
+        let entry = map.get_mut(fingerprint)?;
+        entry.status = "approved".to_string();
+        entry.approved_at = Some(at);
+        let updated = entry.clone();
+        self.save_yubikeys(&map);
+        Some(updated)
+    }
+
+    async fn revoke_yubikey(&self, fingerprint: &str, at: i64) -> Option<YubikeyEntry> {
+        let mut map = self.load_yubikeys();
+        let entry = map.get_mut(fingerprint)?;
+        entry.status = "revoked".to_string();
+        entry.revoked_at = Some(at);
+        let updated = entry.clone();
+        self.save_yubikeys(&map);
+        Some(updated)
+    }
+
+    async fn upsert_yubikey_register(&self, mut entry: YubikeyEntry) -> YubikeyEntry {
+        let mut map = self.load_yubikeys();
+        let (status, registered_at) = match map.get(&entry.fingerprint) {
+            Some(existing) => (
+                existing.status.clone(),
+                existing.registered_at.or(Some(now_epoch_i64())),
+            ),
+            None => ("pending".to_string(), Some(now_epoch_i64())),
+        };
+        entry.status = status;
+        entry.registered_at = registered_at;
+        entry.approved_at = None;
+        entry.revoked_at = None;
+        map.insert(entry.fingerprint.clone(), entry.clone());
+        self.save_yubikeys(&map);
+        entry
+    }
+
+    async fn list_tang(&self) -> Vec<TangServerRow> {
+        self.load_tang().into_values().collect()
+    }
+
+    async fn upsert_tang(&self, row: TangServerRow) {
+        let mut map = self.load_tang();
+        map.insert(row.hostname.clone(), row);
+        self.save_tang(&map);
+    }
+}
+
+// ── Pure parity helpers ───────────────────────────────────────────────────────
+
+/// Strip separators for the `mac-<hexmac>.ipxe` filename convention (Python
+/// `mac_to_hex`, `:75-76`); duplicated from `lifecycle.rs` (private there) —
+/// two 1-line copies of a pure function across disjoint wave-4 files is the
+/// REUSE note's accepted cost (`:51` of the task brief).
+fn mac_to_hex(mac: &str) -> String {
+    mac.to_lowercase().replace([':', '-'], "")
+}
+
+/// Exact port of Python's `find_ipxe_file_by_hostname` (`:103-113`): registry
+/// hostname match first (candidate path is NOT required to exist yet —
+/// existence is checked by the caller), then a fallback scan of `*.ipxe` files
+/// for a `set hostname <name>` content match.
+async fn resolve_ipxe_path(
+    registry: &dyn Registry,
+    ipxe_dir: &Path,
+    hostname: &str,
+) -> Option<PathBuf> {
+    if let Some(m) = registry.find_machine_by_hostname(hostname).await {
+        return Some(ipxe_dir.join(format!("mac-{}.ipxe", mac_to_hex(&m.mac))));
+    }
+    let entries = std::fs::read_dir(ipxe_dir).ok()?;
+    let needle = format!("set hostname {hostname}");
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.extension().and_then(|e| e.to_str()) == Some("ipxe") {
+            if let Ok(content) = std::fs::read_to_string(&p) {
+                if content.contains(&needle) {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Exact port of Python's `flip_ipxe(hostname, target)` (`:170-177`), general
+/// over `target` (unlike `lifecycle.rs`'s webhook-only flip, which is hardwired
+/// to `boot-local-disk`). A missing file (or any IO error) is reported, never
+/// panics.
+async fn flip_ipxe(
+    registry: &dyn Registry,
+    ipxe_dir: &Path,
+    hostname: &str,
+    target: &str,
+) -> (bool, String) {
+    let path = match resolve_ipxe_path(registry, ipxe_dir, hostname).await {
+        Some(p) if p.exists() => p,
+        _ => return (false, format!("No iPXE file found for {hostname}")),
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(err) => return (false, format!("flip failed: {err}")),
+    };
+    let new_content = flip_ipxe_content(&content, target);
+    match std::fs::write(&path, new_content) {
+        Ok(()) => (true, format!("Flipped {hostname} to {target}")),
+        Err(err) => (false, format!("flip failed: {err}")),
+    }
+}
+
+/// Single-quote shell escaping for argv values interpolated into the
+/// [`CommandExecutor`] string-shaped command (it runs via `bash -c`). Prevents
+/// shell injection from attacker-controlled `hostname`/`ip` URL segments.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// argv flag-smuggling guard. `hostname`/`ip` flow as POSITIONAL arguments into a
+/// flag-parsing CLI (`cockroach cert create-node <host>...`). Shell-quoting stops
+/// shell injection but NOT argv smuggling: a value like `--certs-dir=/evil` is a
+/// single well-quoted token that cockroach's flag parser still reads as a flag,
+/// overriding the real `--certs-dir`/`--ca-key`. Reject anything that isn't a
+/// plain host/IP token — empty, leading `-`, or a char outside `[A-Za-z0-9._:-]`.
+fn reject_flaglike(kind: &str, s: &str) -> Result<(), String> {
+    if s.is_empty()
+        || s.starts_with('-')
+        || !s
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b':'))
+    {
+        return Err(format!(
+            "invalid {kind} for cert generation (possible argument injection): {s:?}"
+        ));
+    }
+    Ok(())
+}
+
+/// Exact port of Python's `generate_certs` (`:236-254`): stage `ca.crt` into a
+/// fresh tempdir, shell out `cockroach cert create-node <ip> <hostname>
+/// <hostname>.jf.local localhost 127.0.0.1 --certs-dir=<tmpdir>
+/// --ca-key=<ca_key>` through the [`CommandExecutor`] seam, base64 the three
+/// resulting files. The tempdir is removed on every exit path via
+/// [`tempfile::TempDir`]'s `Drop` (mirrors Python's `try/finally`
+/// `shutil.rmtree`).
+pub async fn generate_certs(
+    executor: &mut (dyn CommandExecutor + Send),
+    ca_crt: &Path,
+    ca_key: &Path,
+    hostname: &str,
+    ip: &str,
+) -> Result<BTreeMap<String, String>, String> {
+    // Fail-closed BEFORE staging or shelling out: identity values must be plain
+    // host/IP tokens, never flag-like (argv smuggling into cockroach's parser).
+    reject_flaglike("hostname", hostname)?;
+    reject_flaglike("ip", ip)?;
+
+    let tmpdir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let dest_ca = tmpdir.path().join("ca.crt");
+    std::fs::copy(ca_crt, &dest_ca).map_err(|e| e.to_string())?;
+
+    let certs_dir = tmpdir.path().display().to_string();
+    let command = format!(
+        "cockroach cert create-node {} {} {} localhost 127.0.0.1 --certs-dir={} --ca-key={}",
+        shell_quote(ip),
+        shell_quote(hostname),
+        shell_quote(&format!("{hostname}.jf.local")),
+        shell_quote(&certs_dir),
+        shell_quote(&ca_key.display().to_string()),
+    );
+
+    let (exit_code, _stdout, stderr) = executor
+        .execute_with_error_collection(&command, "cockroach cert create-node")
+        .await
+        .map_err(|e| e.to_string())?;
+    if exit_code != 0 {
+        return Err(stderr);
+    }
+
+    let mut certs = BTreeMap::new();
+    for fname in ["ca.crt", "node.crt", "node.key"] {
+        let bytes = std::fs::read(tmpdir.path().join(fname)).map_err(|e| e.to_string())?;
+        certs.insert(
+            fname.to_string(),
+            base64::engine::general_purpose::STANDARD.encode(bytes),
+        );
+    }
+    Ok(certs)
+}
+
+fn now_epoch_i64() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn now_epoch_string() -> String {
+    now_epoch_i64().to_string()
+}
+
+// ── Router / handler wiring ──────────────────────────────────────────────────
+
+/// Factory for a fresh boxed [`CommandExecutor`] per cert-issuance call
+/// (the trait's methods take `&mut self`, so a shared instance would need
+/// external locking; a factory keeps each request's executor independent).
+type ExecutorFactory = dyn Fn() -> Box<dyn CommandExecutor + Send> + Send + Sync;
+
+#[derive(Clone)]
+struct AppState {
+    registry: Arc<dyn Registry>,
+    ipxe_dir: Arc<PathBuf>,
+    ca_crt: Arc<PathBuf>,
+    ca_key: Arc<PathBuf>,
+    executor_factory: Arc<ExecutorFactory>,
+}
+
+fn default_state() -> AppState {
+    AppState {
+        registry: Arc::new(FileRegistry::new(
+            StatePaths::default(),
+            PathBuf::from(YUBIKEY_REGISTRY_FILE),
+            PathBuf::from(TANG_REGISTRY_FILE),
+            PathBuf::from(EVENTS_LOG),
+        )),
+        ipxe_dir: Arc::new(PathBuf::from(IPXE_BOOT_DIR)),
+        ca_crt: Arc::new(PathBuf::from(COCKROACH_CA_CRT)),
+        ca_key: Arc::new(PathBuf::from(COCKROACH_CA_KEY)),
+        executor_factory: Arc::new(|| Box::new(LocalClient::new()) as Box<dyn CommandExecutor + Send>),
+    }
+}
+
+/// The inventory sub-router. Merged into `machine_plane::router()` by the
+/// coordinator with `.merge(inventory::router())` (one line, owned by CT-01's
+/// `mod.rs` — never edited here). Also carries the machine-plane catch-all
+/// `404 {"error":"not found"}` fallback (Python `:558,711`); no sibling
+/// submodule sets one today (grep-verified before writing this file).
+pub fn router() -> Router {
+    build_router(default_state())
+}
+
+fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/certs/:hostname", get(handle_certs))
+        .route("/api/flip/:hostname", get(handle_flip))
+        .route("/api/approve/:mac", get(handle_approve))
+        .route("/api/deregister/:mac", get(handle_deregister))
+        .route("/api/registry", get(handle_registry))
+        .route("/api/events", get(handle_events))
+        .route("/api/yubikeys", get(handle_yubikeys_list))
+        .route("/api/yubikeys/ssh-keys", get(handle_yubikeys_ssh_keys))
+        .route("/api/yubikeys/approve/:fp", get(handle_yubikey_approve))
+        .route("/api/yubikeys/:fp/pubkey", get(handle_yubikey_pubkey))
+        .route("/api/yubikeys/revoke/:fp", get(handle_yubikey_revoke))
+        .route("/api/tang/servers", get(handle_tang_servers))
+        .route("/api/yubikeys/register", post(handle_yubikey_register))
+        .route("/api/tang/checkin", post(handle_tang_checkin))
+        .fallback(handle_not_found)
+        .with_state(state)
+}
+
+fn json_response(code: StatusCode, body: Value) -> Response {
+    (code, Json(body)).into_response()
+}
+
+/// Machine-plane catch-all (Python `:558` GET fallthrough, `:711` POST
+/// fallthrough) — deliberately `{"error":"not found"}`, NOT the `{"ok":false,
+/// "error":...}` shape every matched-route error uses.
+async fn handle_not_found() -> Response {
+    json_response(StatusCode::NOT_FOUND, json!({"error": "not found"}))
+}
+
+#[derive(Debug, Deserialize)]
+struct CertsQuery {
+    #[serde(default)]
+    ip: Option<String>,
+    #[serde(default)]
+    mac: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlipQuery {
+    #[serde(default)]
+    target: Option<String>,
+}
+
+// ── /api/certs/<hostname> (Python `:286-312`) ────────────────────────────────
+
+async fn handle_certs(
+    State(state): State<AppState>,
+    AxumPath(hostname): AxumPath<String>,
+    Query(q): Query<CertsQuery>,
+) -> Response {
+    let ip = q.ip.unwrap_or_else(|| "127.0.0.1".to_string());
+    let mac_param = q.mac.unwrap_or_default();
+
+    // Order matches Python exactly: mac-param lookup -> hostname-scan fallback.
+    let mut entry = None;
+    if !mac_param.is_empty() {
+        let mac = normalize_mac(&mac_param);
+        entry = state.registry.get_machine(&mac).await;
+    }
+    if entry.is_none() {
+        entry = state.registry.find_machine_by_hostname(&hostname).await;
+    }
+    let entry = match entry {
+        None => {
+            tracing::info!(%hostname, %ip, "CERTS DENIED - not registered");
+            return json_response(
+                StatusCode::FORBIDDEN,
+                json!({"ok": false, "error": "Not registered. Run register-len-server.sh first."}),
+            );
+        }
+        Some(e) => e,
+    };
+    if entry.status != MachineStatus::Approved {
+        let status_str: String = entry.status.clone().into();
+        tracing::info!(%hostname, status = %status_str, "CERTS DENIED - not approved");
+        return json_response(
+            StatusCode::FORBIDDEN,
+            json!({"ok": false, "error": format!("Pending approval. Status: {status_str}.")}),
+        );
+    }
+
+    let mut executor = (state.executor_factory)();
+    match generate_certs(executor.as_mut(), &state.ca_crt, &state.ca_key, &hostname, &ip).await {
+        Err(err) => json_response(StatusCode::INTERNAL_SERVER_ERROR, json!({"ok": false, "error": err})),
+        Ok(certs) => {
+            tracing::info!(%hostname, %ip, "CERTS issued");
+            json_response(StatusCode::OK, json!({"ok": true, "certs": certs}))
+        }
+    }
+}
+
+// ── /api/flip/<hostname> (Python `:315-329`) ─────────────────────────────────
+
+async fn handle_flip(
+    State(state): State<AppState>,
+    AxumPath(hostname): AxumPath<String>,
+    Query(q): Query<FlipQuery>,
+) -> Response {
+    let target = q.target.unwrap_or_else(|| "boot-local-disk".to_string());
+    if target == "custom-autoinstall" {
+        let approved = state
+            .registry
+            .find_machine_by_hostname(&hostname)
+            .await
+            .map(|e| e.status == MachineStatus::Approved)
+            .unwrap_or(false);
+        if !approved {
+            tracing::info!(%hostname, "FLIP TO INSTALL DENIED - not approved");
+            return json_response(
+                StatusCode::FORBIDDEN,
+                json!({"ok": false, "error": "Flip to reinstall requires approved status"}),
+            );
+        }
+    }
+    let (ok, msg) = flip_ipxe(state.registry.as_ref(), &state.ipxe_dir, &hostname, &target).await;
+    tracing::info!(%hostname, %target, %ok, %msg, "FLIP");
+    let code = if ok { StatusCode::OK } else { StatusCode::NOT_FOUND };
+    json_response(code, json!({"ok": ok, "message": msg}))
+}
+
+// ── /api/approve/<mac> (Python `:332-344`) ───────────────────────────────────
+
+async fn handle_approve(State(state): State<AppState>, AxumPath(mac_raw): AxumPath<String>) -> Response {
+    let mac = normalize_mac(&mac_raw);
+    if state.registry.get_machine(&mac).await.is_none() {
+        return json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "MAC not registered"}));
+    }
+    match state.registry.approve_machine(&mac, now_epoch_string()).await {
+        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "MAC not registered"})),
+        Some(row) => {
+            tracing::info!(%mac, hostname = %row.hostname, "APPROVED");
+            json_response(
+                StatusCode::OK,
+                json!({"ok": true, "message": format!("Approved {mac}"), "entry": row}),
+            )
+        }
+    }
+}
+
+// ── /api/deregister/<mac> (Python `:347-359`) ────────────────────────────────
+
+async fn handle_deregister(State(state): State<AppState>, AxumPath(mac_raw): AxumPath<String>) -> Response {
+    let mac = normalize_mac(&mac_raw);
+    match state.registry.delete_machine(&mac).await {
+        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "MAC not registered"})),
+        Some(row) => {
+            tracing::info!(%mac, hostname = %row.hostname, "DEREGISTERED");
+            json_response(
+                StatusCode::OK,
+                json!({"ok": true, "message": format!("Deregistered {mac} ({})", row.hostname)}),
+            )
+        }
+    }
+}
+
+// ── /api/registry (Python `:401-403`) ────────────────────────────────────────
+
+async fn handle_registry(State(state): State<AppState>) -> Response {
+    let machines = state.registry.list_machines().await;
+    let mut map = serde_json::Map::new();
+    for m in machines {
+        let mac = m.mac.clone();
+        map.insert(mac, serde_json::to_value(&m).unwrap_or(Value::Null));
+    }
+    json_response(StatusCode::OK, Value::Object(map))
+}
+
+// ── /api/events (Python `:406-412`) ──────────────────────────────────────────
+
+async fn handle_events(State(state): State<AppState>) -> Response {
+    let events = state.registry.list_events(50).await;
+    json_response(StatusCode::OK, Value::Array(events))
+}
+
+// ── /api/yubikeys (Python `:418-424`) ────────────────────────────────────────
+
+async fn handle_yubikeys_list(State(state): State<AppState>) -> Response {
+    let yk = state.registry.list_yubikeys().await;
+    let mut map = serde_json::Map::new();
+    for entry in &yk {
+        map.insert(entry.fingerprint.clone(), entry.without_gpg_pubkey());
+    }
+    json_response(StatusCode::OK, Value::Object(map))
+}
+
+// ── /api/yubikeys/ssh-keys (Python `:426-431`) ───────────────────────────────
+
+async fn handle_yubikeys_ssh_keys(State(state): State<AppState>) -> Response {
+    let yk = state.registry.list_yubikeys().await;
+    let keys: Vec<String> = yk
+        .into_iter()
+        .filter(|e| e.status == "approved")
+        .filter_map(|e| e.ssh_pubkey.filter(|s| !s.is_empty()))
+        .collect();
+    json_response(StatusCode::OK, json!({"keys": keys}))
+}
+
+// ── /api/yubikeys/approve/<fingerprint> (Python `:433-446`) ──────────────────
+
+async fn handle_yubikey_approve(State(state): State<AppState>, AxumPath(fp_raw): AxumPath<String>) -> Response {
+    let fp = fp_raw.to_uppercase();
+    match state.registry.approve_yubikey(&fp, now_epoch_i64()).await {
+        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "Fingerprint not registered"})),
+        Some(entry) => {
+            tracing::info!(fingerprint = %fp, comment = ?entry.comment, "YUBIKEY APPROVED");
+            json_response(
+                StatusCode::OK,
+                json!({"ok": true, "fingerprint": fp, "entry": entry.without_gpg_pubkey()}),
+            )
+        }
+    }
+}
+
+// ── /api/yubikeys/<FP>/pubkey (Python `:448-465`) ────────────────────────────
+
+/// Python's route regex is `^/api/yubikeys/([A-F0-9]+)/pubkey$` — a lowercase
+/// or otherwise malformed fingerprint never matches that route at all, so it
+/// falls through to the generic catch-all `{"error":"not found"}`, NOT the
+/// `{"ok":false,"error":"No GPG key..."}` this handler uses for a
+/// well-formed-but-unknown fingerprint.
+fn is_valid_fp_format(fp: &str) -> bool {
+    !fp.is_empty() && fp.chars().all(|c| c.is_ascii_digit() || ('A'..='F').contains(&c))
+}
+
+async fn handle_yubikey_pubkey(State(state): State<AppState>, AxumPath(fp): AxumPath<String>) -> Response {
+    if !is_valid_fp_format(&fp) {
+        return handle_not_found().await;
+    }
+    let entry = state.registry.get_yubikey(&fp).await;
+    let entry = match entry {
+        Some(e) if e.gpg_pubkey.as_deref().is_some_and(|k| !k.is_empty()) => e,
+        _ => {
+            return json_response(
+                StatusCode::NOT_FOUND,
+                json!({"ok": false, "error": "No GPG key for that fingerprint"}),
+            )
+        }
+    };
+    if entry.status != "approved" {
+        return json_response(StatusCode::FORBIDDEN, json!({"ok": false, "error": "YubiKey not approved"}));
+    }
+    let body = entry.gpg_pubkey.unwrap_or_default();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/pgp-keys")
+        .body(axum::body::Body::from(body))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+// ── /api/yubikeys/revoke/<fingerprint> (Python `:467-480`) ───────────────────
+
+async fn handle_yubikey_revoke(State(state): State<AppState>, AxumPath(fp_raw): AxumPath<String>) -> Response {
+    let fp = fp_raw.to_uppercase();
+    match state.registry.revoke_yubikey(&fp, now_epoch_i64()).await {
+        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "Fingerprint not registered"})),
+        Some(entry) => {
+            tracing::info!(fingerprint = %fp, comment = ?entry.comment, "YUBIKEY REVOKED");
+            json_response(StatusCode::OK, json!({"ok": true, "message": format!("Revoked {fp}")}))
+        }
+    }
+}
+
+// ── /api/tang/servers (Python `:487-490`) ────────────────────────────────────
+
+async fn handle_tang_servers(State(state): State<AppState>) -> Response {
+    let tang = state.registry.list_tang().await;
+    let mut map = serde_json::Map::new();
+    for row in tang {
+        map.insert(row.hostname.clone(), serde_json::to_value(&row).unwrap_or(Value::Null));
+    }
+    json_response(StatusCode::OK, Value::Object(map))
+}
+
+// ── POST /api/yubikeys/register (Python `:660-689`) ──────────────────────────
+
+/// Parse the raw request body as JSON, or short-circuit with the same
+/// `400 {"error": "invalid json"}` shape every legacy POST route shares
+/// (Python's `do_POST` dispatcher, `:564-568`).
+#[allow(clippy::result_large_err)]
+fn parse_json(body: &Bytes) -> Result<Value, Response> {
+    serde_json::from_slice(body)
+        .map_err(|_| json_response(StatusCode::BAD_REQUEST, json!({"error": "invalid json"})))
+}
+
+async fn handle_yubikey_register(State(state): State<AppState>, body: Bytes) -> Response {
+    let data = match parse_json(&body) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    let fp = data
+        .get("fingerprint")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_uppercase()
+        .replace(' ', "");
+    if fp.is_empty() {
+        return json_response(StatusCode::BAD_REQUEST, json!({"ok": false, "error": "fingerprint required"}));
+    }
+
+    let entry = YubikeyEntry {
+        fingerprint: fp.clone(),
+        gpg_pubkey: data.get("gpg_pubkey").and_then(Value::as_str).map(str::to_string),
+        ssh_pubkey: data.get("ssh_pubkey").and_then(Value::as_str).map(str::to_string),
+        comment: data.get("comment").and_then(Value::as_str).map(str::to_string),
+        serial: data.get("serial").and_then(Value::as_str).map(str::to_string),
+        status: String::new(),  // overwritten by upsert_yubikey_register
+        registered_at: None,    // overwritten by upsert_yubikey_register
+        approved_at: None,
+        revoked_at: None,
+    };
+    let saved = state.registry.upsert_yubikey_register(entry).await;
+
+    let approve_url = format!("http://172.16.2.30:25000/api/yubikeys/approve/{fp}");
+    tracing::info!(fingerprint = %fp, status = %saved.status, "YUBIKEY register");
+    json_response(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "status": saved.status,
+            "message": format!("Registered. Approve with: curl {approve_url}"),
+        }),
+    )
+}
+
+// ── POST /api/tang/checkin (Python `:692-709`) ────────────────────────────────
+
+async fn handle_tang_checkin(State(state): State<AppState>, body: Bytes) -> Response {
+    let data = match parse_json(&body) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    let hostname = data.get("hostname").and_then(Value::as_str).unwrap_or("").to_string();
+    let ip = data.get("ip").and_then(Value::as_str).unwrap_or("").to_string();
+    let tang_url = data
+        .get("tang_url")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("http://{ip}"));
+    let adv_keys = data.get("adv_keys").cloned();
+    let adv_keys_count = adv_keys.as_ref().and_then(Value::as_array).map(Vec::len).unwrap_or(0);
+
+    let row = TangServerRow {
+        hostname: hostname.clone(),
+        ip: Some(ip.clone()),
+        tang_url: Some(tang_url),
+        adv_keys,
+        last_seen: Some(now_epoch_string()),
+    };
+    state.registry.upsert_tang(row).await;
+
+    tracing::info!(%hostname, %ip, keys = adv_keys_count, "TANG CHECKIN");
+    json_response(StatusCode::OK, json!({"ok": true}))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+    use uaa_core::Result as CoreResult;
+
+    // ── in-memory mock Registry — zero filesystem, zero CRDB ─────────────
+
+    #[derive(Default)]
+    struct MockRegistry {
+        machines: Mutex<HashMap<String, MachineRow>>,
+        yubikeys: Mutex<HashMap<String, YubikeyEntry>>,
+        tang: Mutex<HashMap<String, TangServerRow>>,
+        events: Mutex<Vec<Value>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Registry for MockRegistry {
+        async fn get_machine(&self, mac: &str) -> Option<MachineRow> {
+            self.machines.lock().unwrap().get(mac).cloned()
+        }
+        async fn find_machine_by_hostname(&self, hostname: &str) -> Option<MachineRow> {
+            self.machines
+                .lock()
+                .unwrap()
+                .values()
+                .find(|m| m.hostname == hostname)
+                .cloned()
+        }
+        async fn list_machines(&self) -> Vec<MachineRow> {
+            self.machines.lock().unwrap().values().cloned().collect()
+        }
+        async fn approve_machine(&self, mac: &str, approved_at: String) -> Option<MachineRow> {
+            let mut st = self.machines.lock().unwrap();
+            let row = st.get_mut(mac)?;
+            row.status = MachineStatus::Approved;
+            row.approved_at = Some(approved_at);
+            Some(row.clone())
+        }
+        async fn delete_machine(&self, mac: &str) -> Option<MachineRow> {
+            self.machines.lock().unwrap().remove(mac)
+        }
+        async fn list_events(&self, limit: usize) -> Vec<Value> {
+            let events = self.events.lock().unwrap();
+            let start = events.len().saturating_sub(limit);
+            events[start..].to_vec()
+        }
+        async fn list_yubikeys(&self) -> Vec<YubikeyEntry> {
+            self.yubikeys.lock().unwrap().values().cloned().collect()
+        }
+        async fn get_yubikey(&self, fingerprint: &str) -> Option<YubikeyEntry> {
+            self.yubikeys.lock().unwrap().get(fingerprint).cloned()
+        }
+        async fn approve_yubikey(&self, fingerprint: &str, at: i64) -> Option<YubikeyEntry> {
+            let mut st = self.yubikeys.lock().unwrap();
+            let e = st.get_mut(fingerprint)?;
+            e.status = "approved".to_string();
+            e.approved_at = Some(at);
+            Some(e.clone())
+        }
+        async fn revoke_yubikey(&self, fingerprint: &str, at: i64) -> Option<YubikeyEntry> {
+            let mut st = self.yubikeys.lock().unwrap();
+            let e = st.get_mut(fingerprint)?;
+            e.status = "revoked".to_string();
+            e.revoked_at = Some(at);
+            Some(e.clone())
+        }
+        async fn upsert_yubikey_register(&self, mut entry: YubikeyEntry) -> YubikeyEntry {
+            let mut st = self.yubikeys.lock().unwrap();
+            let (status, registered_at) = match st.get(&entry.fingerprint) {
+                Some(existing) => (existing.status.clone(), existing.registered_at.or(Some(1))),
+                None => ("pending".to_string(), Some(1)),
+            };
+            entry.status = status;
+            entry.registered_at = registered_at;
+            entry.approved_at = None;
+            entry.revoked_at = None;
+            st.insert(entry.fingerprint.clone(), entry.clone());
+            entry
+        }
+        async fn list_tang(&self) -> Vec<TangServerRow> {
+            self.tang.lock().unwrap().values().cloned().collect()
+        }
+        async fn upsert_tang(&self, row: TangServerRow) {
+            self.tang.lock().unwrap().insert(row.hostname.clone(), row);
+        }
+    }
+
+    // ── mock CommandExecutor — writes fake certs, records argv ───────────
+
+    fn extract_certs_dir(command: &str) -> Option<String> {
+        // `shell_quote` wraps the VALUE, not the whole `--flag=value` token, so
+        // the trim must happen AFTER stripping the flag prefix (e.g.
+        // `--certs-dir='/tmp/x'` -> `'/tmp/x'` -> `/tmp/x`).
+        for token in command.split_whitespace() {
+            if let Some(dir) = token.strip_prefix("--certs-dir=") {
+                return Some(dir.trim_matches('\'').to_string());
+            }
+        }
+        None
+    }
+
+    // ── fixtures ───────────────────────────────────────────────────────
+
+    fn base_machine(mac: &str, hostname: &str, status: MachineStatus) -> MachineRow {
+        MachineRow {
+            mac: mac.to_string(),
+            hostname: hostname.to_string(),
+            ip: Some("10.0.0.1".to_string()),
+            r#type: "lenovo".to_string(),
+            status,
+            boot_target: crate::db::BootTarget::LocalDisk,
+            tpm_ek: None,
+            registered_at: Some("1000".to_string()),
+            approved_at: None,
+            last_seen: None,
+            last_ip: None,
+            installed_at: None,
+            last_install_status: None,
+            updated_at: None,
+        }
+    }
+
+    fn test_state(registry: Arc<dyn Registry>, ipxe_dir: PathBuf, recorded: Arc<Mutex<Vec<String>>>) -> AppState {
+        AppState {
+            registry,
+            ipxe_dir: Arc::new(ipxe_dir),
+            ca_crt: Arc::new(PathBuf::new()),
+            ca_key: Arc::new(PathBuf::new()),
+            executor_factory: Arc::new(move || {
+                let recorded = recorded.clone();
+                Box::new(RecordingExecutor { recorded }) as Box<dyn CommandExecutor + Send>
+            }),
+        }
+    }
+
+    /// Wraps [`MockExecutor`] so its recorded argv is visible to the test after
+    /// the (moved, boxed) executor is dropped.
+    struct RecordingExecutor {
+        recorded: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CommandExecutor for RecordingExecutor {
+        async fn connect(&mut self, _host: &str, _username: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        async fn execute(&mut self, _command: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        async fn execute_with_output(&mut self, _command: &str) -> CoreResult<String> {
+            Ok(String::new())
+        }
+        async fn execute_with_error_collection(
+            &mut self,
+            command: &str,
+            _description: &str,
+        ) -> CoreResult<(i32, String, String)> {
+            self.recorded.lock().unwrap().push(command.to_string());
+            if let Some(dir) = extract_certs_dir(command) {
+                let _ = std::fs::write(Path::new(&dir).join("node.crt"), b"FAKE-NODE-CRT");
+                let _ = std::fs::write(Path::new(&dir).join("node.key"), b"FAKE-NODE-KEY");
+            }
+            Ok((0, String::new(), String::new()))
+        }
+        async fn check_silent(&mut self, _command: &str) -> CoreResult<bool> {
+            Ok(true)
+        }
+        async fn collect_debug_info(&mut self) -> CoreResult<String> {
+            Ok(String::new())
+        }
+        async fn upload_file(&mut self, _local: &str, _remote: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        async fn download_file(&mut self, _remote: &str, _local: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        fn disconnect(&mut self) {}
+    }
+
+    async fn body_json(resp: Response) -> Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn write_ipxe(dir: &Path, filename: &str, content: &str) -> PathBuf {
+        let p = dir.join(filename);
+        std::fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn test_router_builds_standalone() {
+        // Constructing the router touches no filesystem/network — only requests do.
+        let _ = router();
+    }
+
+    /// Mirrors the EXACT merge shape `machine_plane::mod.rs` performs at wiring
+    /// time (`.route("/healthz", ...).merge(lifecycle::router()).merge(inventory::router())`)
+    /// — proves no route/method collides with `lifecycle`'s POST routes and that
+    /// this module's `.fallback()` merges cleanly (neither `/healthz` nor
+    /// `lifecycle::router()` sets one, so axum does not see two competing
+    /// fallbacks).
+    #[test]
+    fn test_merges_into_machine_plane_router() {
+        let _: axum::Router = axum::Router::new()
+            .route(
+                "/healthz",
+                get(|| async { Json(json!({"service": "uaa-control"})) }),
+            )
+            .merge(super::super::lifecycle::router())
+            .merge(router());
+    }
+
+    // ── /api/certs ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_certs_unregistered_403() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_certs(
+            State(state),
+            AxumPath("ghost-host".to_string()),
+            Query(CertsQuery { ip: None, mac: None }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"], "Not registered. Run register-len-server.sh first.");
+    }
+
+    #[tokio::test]
+    async fn test_certs_unapproved_403() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry.machines.lock().unwrap().insert(
+            "aa:bb:cc:dd:ee:ff".to_string(),
+            base_machine("aa:bb:cc:dd:ee:ff", "pending-host", MachineStatus::Pending),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_certs(
+            State(state),
+            AxumPath("pending-host".to_string()),
+            Query(CertsQuery { ip: None, mac: None }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"], "Pending approval. Status: pending.");
+    }
+
+    #[tokio::test]
+    async fn test_certs_approved_issues() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry.machines.lock().unwrap().insert(
+            "aa:bb:cc:dd:ee:ff".to_string(),
+            base_machine("aa:bb:cc:dd:ee:ff", "ok-host", MachineStatus::Approved),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let ca_dir = tempdir().unwrap();
+        std::fs::write(ca_dir.path().join("ca.crt"), b"FAKE-CA").unwrap();
+        let mut state = test_state(registry, dir.path().to_path_buf(), recorded.clone());
+        state.ca_crt = Arc::new(ca_dir.path().join("ca.crt"));
+        state.ca_key = Arc::new(ca_dir.path().join("ca.key"));
+
+        let resp = handle_certs(
+            State(state),
+            AxumPath("ok-host".to_string()),
+            Query(CertsQuery { ip: Some("10.0.0.9".to_string()), mac: None }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+        let certs = v["certs"].as_object().unwrap();
+        assert_eq!(certs.len(), 3);
+        assert!(certs.contains_key("ca.crt"));
+        assert!(certs.contains_key("node.crt"));
+        assert!(certs.contains_key("node.key"));
+
+        let cmds = recorded.lock().unwrap();
+        assert_eq!(cmds.len(), 1);
+        assert!(cmds[0].contains("cert create-node"));
+        assert!(cmds[0].contains("ok-host.jf.local"));
+    }
+
+    // ── /api/flip ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_flip_install_requires_approved() {
+        let dir = tempdir().unwrap();
+        write_ipxe(dir.path(), "mac-aabbccddeeff.ipxe", "#!ipxe\nset menu-default pxe-install\nboot\n");
+        let registry = Arc::new(MockRegistry::default());
+        registry.machines.lock().unwrap().insert(
+            "aa:bb:cc:dd:ee:ff".to_string(),
+            base_machine("aa:bb:cc:dd:ee:ff", "flip-host", MachineStatus::Pending),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry.clone(), dir.path().to_path_buf(), recorded);
+
+        let resp = handle_flip(
+            State(state.clone()),
+            AxumPath("flip-host".to_string()),
+            Query(FlipQuery { target: Some("custom-autoinstall".to_string()) }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "Flip to reinstall requires approved status");
+
+        // Anti-over-suppression: approve, then the SAME target must succeed.
+        registry
+            .approve_machine("aa:bb:cc:dd:ee:ff", "123".to_string())
+            .await
+            .unwrap();
+        let resp2 = handle_flip(
+            State(state),
+            AxumPath("flip-host".to_string()),
+            Query(FlipQuery { target: Some("custom-autoinstall".to_string()) }),
+        )
+        .await;
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let v2 = body_json(resp2).await;
+        assert_eq!(v2["ok"], true);
+        let content = std::fs::read_to_string(dir.path().join("mac-aabbccddeeff.ipxe")).unwrap();
+        assert!(content.contains("set menu-default custom-autoinstall"));
+    }
+
+    #[tokio::test]
+    async fn test_flip_local_disk_no_registration_needed() {
+        let dir = tempdir().unwrap();
+        write_ipxe(dir.path(), "some-file.ipxe", "#!ipxe\nset hostname unreg-host\nset menu-default pxe-install\nboot\n");
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_flip(
+            State(state),
+            AxumPath("unreg-host".to_string()),
+            Query(FlipQuery { target: None }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+        let content = std::fs::read_to_string(dir.path().join("some-file.ipxe")).unwrap();
+        assert!(content.contains("set menu-default boot-local-disk"));
+    }
+
+    #[tokio::test]
+    async fn test_flip_missing_file_404() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_flip(
+            State(state),
+            AxumPath("no-such-host".to_string()),
+            Query(FlipQuery { target: None }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], false);
+    }
+
+    // ── /api/approve, /api/deregister ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_approve_unknown_404() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_approve(State(state), AxumPath("aa:bb:cc:dd:ee:ff".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"], "MAC not registered");
+    }
+
+    #[tokio::test]
+    async fn test_approve_sets_status() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry.machines.lock().unwrap().insert(
+            "aa:bb:cc:dd:ee:ff".to_string(),
+            base_machine("aa:bb:cc:dd:ee:ff", "approve-host", MachineStatus::Pending),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_approve(State(state), AxumPath("AA-BB-CC-DD-EE-FF".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["message"], "Approved aa:bb:cc:dd:ee:ff");
+        assert_eq!(v["entry"]["status"], "approved");
+        assert!(v["entry"]["approved_at"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_deregister_unknown_404() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_deregister(State(state), AxumPath("aa:bb:cc:dd:ee:ff".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "MAC not registered");
+    }
+
+    #[tokio::test]
+    async fn test_deregister_removes_only_registry_row() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry.machines.lock().unwrap().insert(
+            "aa:bb:cc:dd:ee:ff".to_string(),
+            base_machine("aa:bb:cc:dd:ee:ff", "gone-host", MachineStatus::Approved),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry.clone(), dir.path().to_path_buf(), recorded);
+
+        let resp = handle_deregister(State(state), AxumPath("aa:bb:cc:dd:ee:ff".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["message"], "Deregistered aa:bb:cc:dd:ee:ff (gone-host)");
+        assert!(registry.get_machine("aa:bb:cc:dd:ee:ff").await.is_none());
+    }
+
+    // ── /api/registry, /api/events ───────────────────────────────────
+
+    #[tokio::test]
+    async fn test_registry_empty_map_200() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_registry(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v, json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_events_read_error_empty_200() {
+        // Real FileRegistry pointed at a nonexistent events file — the actual
+        // error path Python's bare `except` swallows (`:406-412`).
+        let dir = tempdir().unwrap();
+        let fr = FileRegistry::new(
+            StatePaths::under(dir.path()),
+            dir.path().join("yubikeys.json"),
+            dir.path().join("tang.json"),
+            dir.path().join("does-not-exist.jsonl"),
+        );
+        let events = fr.list_events(50).await;
+        assert!(events.is_empty());
+
+        // Also exercise the corrupt-line path.
+        std::fs::write(dir.path().join("events2.jsonl"), "not json\n").unwrap();
+        let fr2 = FileRegistry::new(
+            StatePaths::under(dir.path()),
+            dir.path().join("yubikeys.json"),
+            dir.path().join("tang.json"),
+            dir.path().join("events2.jsonl"),
+        );
+        assert!(fr2.list_events(50).await.is_empty());
+
+        // Handler-level check via the mock (empty events vec -> 200 []).
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+        let resp = handle_events(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v, json!([]));
+    }
+
+    // ── yubikeys ──────────────────────────────────────────────────────
+
+    fn sample_yubikey(fp: &str, status: &str, gpg: Option<&str>, ssh: Option<&str>) -> YubikeyEntry {
+        YubikeyEntry {
+            fingerprint: fp.to_string(),
+            gpg_pubkey: gpg.map(str::to_string),
+            ssh_pubkey: ssh.map(str::to_string),
+            comment: Some("test key".to_string()),
+            serial: Some("12345".to_string()),
+            status: status.to_string(),
+            registered_at: Some(1000),
+            approved_at: None,
+            revoked_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_yubikey_listing_strips_gpg() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry.yubikeys.lock().unwrap().insert(
+            "DEADBEEF".to_string(),
+            sample_yubikey("DEADBEEF", "approved", Some("-----BEGIN PGP PUBLIC KEY-----\nabc\n"), Some("ssh-ed25519 AAAA")),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_yubikeys_list(State(state.clone())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        let entry = &v["DEADBEEF"];
+        assert!(entry.get("gpg_pubkey").is_none(), "gpg_pubkey must be stripped from listing");
+        assert_eq!(entry["status"], "approved");
+
+        // /pubkey still returns the armored block for an approved fp.
+        let resp2 = handle_yubikey_pubkey(State(state.clone()), AxumPath("DEADBEEF".to_string())).await;
+        assert_eq!(resp2.status(), StatusCode::OK);
+        assert_eq!(
+            resp2.headers().get("content-type").unwrap(),
+            "application/pgp-keys"
+        );
+        let bytes = axum::body::to_bytes(resp2.into_body(), usize::MAX).await.unwrap();
+        assert!(String::from_utf8_lossy(&bytes).contains("BEGIN PGP PUBLIC KEY"));
+
+        // Unapproved fp -> 403 on /pubkey.
+        let state2 = state.clone();
+        state2.registry.upsert_yubikey_register(sample_yubikey("ABCDEF01", "pending", Some("armored"), None)).await;
+        let resp3 = handle_yubikey_pubkey(State(state2), AxumPath("ABCDEF01".to_string())).await;
+        assert_eq!(resp3.status(), StatusCode::FORBIDDEN);
+        let v3 = body_json(resp3).await;
+        assert_eq!(v3["error"], "YubiKey not approved");
+    }
+
+    #[tokio::test]
+    async fn test_yubikey_pubkey_lowercase_falls_through_404() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        registry.yubikeys.lock().unwrap().insert(
+            "DEADBEEF".to_string(),
+            sample_yubikey("DEADBEEF", "approved", Some("armored"), None),
+        );
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        // Lowercase never matches Python's `[A-F0-9]+` route regex -> generic catch-all.
+        let resp = handle_yubikey_pubkey(State(state), AxumPath("deadbeef".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v, json!({"error": "not found"}));
+    }
+
+    #[tokio::test]
+    async fn test_yubikey_approve_and_revoke_unknown_404() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_yubikey_approve(State(state.clone()), AxumPath("nope".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "Fingerprint not registered");
+
+        let resp2 = handle_yubikey_revoke(State(state), AxumPath("nope".to_string())).await;
+        assert_eq!(resp2.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_yubikey_ssh_keys_only_approved_nonempty() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        {
+            let mut yk = registry.yubikeys.lock().unwrap();
+            yk.insert("A".to_string(), sample_yubikey("A", "approved", None, Some("ssh-key-a")));
+            yk.insert("B".to_string(), sample_yubikey("B", "pending", None, Some("ssh-key-b")));
+            yk.insert("C".to_string(), sample_yubikey("C", "approved", None, Some("")));
+        }
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_yubikeys_ssh_keys(State(state)).await;
+        let v = body_json(resp).await;
+        let keys = v["keys"].as_array().unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0], "ssh-key-a");
+    }
+
+    #[tokio::test]
+    async fn test_yubikey_register_upsert_preserves_status() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry.clone(), dir.path().to_path_buf(), recorded);
+
+        let body = Bytes::from(serde_json::to_vec(&json!({"fingerprint": " dead beef "})).unwrap());
+        let resp = handle_yubikey_register(State(state.clone()), body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["status"], "pending");
+
+        registry.approve_yubikey("DEADBEEF", 555).await.unwrap();
+
+        // Re-register: status must be PRESERVED (approved), not reset to pending.
+        let body2 = Bytes::from(
+            serde_json::to_vec(&json!({"fingerprint": "DEADBEEF", "comment": "updated"})).unwrap(),
+        );
+        let resp2 = handle_yubikey_register(State(state), body2).await;
+        let v2 = body_json(resp2).await;
+        assert_eq!(v2["status"], "approved");
+    }
+
+    #[tokio::test]
+    async fn test_yubikey_register_missing_fingerprint_400() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let body = Bytes::from(serde_json::to_vec(&json!({})).unwrap());
+        let resp = handle_yubikey_register(State(state), body).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"], "fingerprint required");
+    }
+
+    // ── tang ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_tang_checkin_and_list() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let body = Bytes::from(
+            serde_json::to_vec(&json!({"hostname": "tang1", "ip": "10.0.0.5", "adv_keys": [1, 2, 3]}))
+                .unwrap(),
+        );
+        let resp = handle_tang_checkin(State(state.clone()), body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["ok"], true);
+
+        let resp2 = handle_tang_servers(State(state)).await;
+        let v2 = body_json(resp2).await;
+        assert_eq!(v2["tang1"]["ip"], "10.0.0.5");
+        assert_eq!(v2["tang1"]["adv_keys"].as_array().unwrap().len(), 3);
+    }
+
+    // ── invalid JSON / catch-all ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_post_invalid_json_400() {
+        let dir = tempdir().unwrap();
+        let registry = Arc::new(MockRegistry::default());
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = test_state(registry, dir.path().to_path_buf(), recorded);
+
+        let resp = handle_yubikey_register(State(state.clone()), Bytes::from_static(b"not json")).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp2 = handle_tang_checkin(State(state), Bytes::from_static(b"{bad")).await;
+        assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_catch_all_404_shape() {
+        let resp = handle_not_found().await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v, json!({"error": "not found"}));
+    }
+
+    #[test]
+    fn test_reject_flaglike_blocks_argv_injection() {
+        // Flag-like identities must be refused before any cert command is built.
+        for evil in ["--certs-dir=/evil", "-x", "a b", "a;b", "$(id)", "a/b"] {
+            assert!(reject_flaglike("hostname", evil).is_err(), "allowed: {evil:?}");
+        }
+        // Anti-over-suppression: legitimate host/IP tokens still pass.
+        for good in ["len-serv-001", "len-serv-001.jf.local", "172.16.2.30", "fe80::1", "host_1"] {
+            assert!(reject_flaglike("hostname", good).is_ok(), "rejected: {good:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_certs_rejects_flaglike_before_exec() {
+        // A flag-like hostname records ZERO executor commands (fail-closed before shell-out).
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let mut exec = RecordingExecutor { recorded: recorded.clone() };
+        let ca = Path::new("/tmp/ca.crt");
+        let err = generate_certs(&mut exec, ca, ca, "--certs-dir=/evil", "172.16.2.30")
+            .await
+            .expect_err("flag-like hostname must be rejected");
+        assert!(err.contains("argument injection"), "{err}");
+        assert_eq!(recorded.lock().unwrap().len(), 0, "no command should run");
+    }
+}

--- a/crates/uaa-control/src/machine_plane/mod.rs
+++ b/crates/uaa-control/src/machine_plane/mod.rs
@@ -1,5 +1,5 @@
 // file: crates/uaa-control/src/machine_plane/mod.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: eee7b5c0-24d0-4406-b5f6-68d5bac52cae
 // last-edited: 2026-07-10
 
@@ -29,8 +29,8 @@ pub fn router() -> Router {
             "/healthz",
             get(|| async { Json(json!({ "service": "uaa-control", "listener": "machine-plane" })) }),
         )
-    // IP-01: .merge(seeds::router()) [reverted — handler trait bound; re-dispatch]
+        .merge(seeds::router()) // IP-01
         .merge(lifecycle::router()) // IP-02
-    // IP-03: .merge(inventory::router())
+        .merge(inventory::router()) // IP-03
     // IP-04: .merge(dashboard::router())
 }

--- a/crates/uaa-control/src/machine_plane/seeds.rs
+++ b/crates/uaa-control/src/machine_plane/seeds.rs
@@ -1,9 +1,488 @@
 // file: crates/uaa-control/src/machine_plane/seeds.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 448eead2-d3b6-4765-8e21-2a7421d3b55e
 // last-edited: 2026-07-10
 
 //! Machine-plane seed placement + boot-target intent (:25000 parity).
 //!
-//! STUB — Filled exclusively by install-plane IP-01. Adds `pub fn router()`, then
-//! merges it into `machine_plane::router()` with one line.
+//! Exact parity with `scripts/autoinstall-agent.py` (spec Decision 12) for the
+//! five auto-resolved GET endpoints: `/autoinstall/{user-data,meta-data,
+//! vendor-data,network-config}` (Python `:496-519`) and `/autoinstall/uaa-config`
+//! (Python `:530-556`). MAC resolution mirrors `mac_from_neighbor_table`
+//! (Python `:186-194`): `ip neigh show <client_ip>` through the
+//! [`CommandExecutor`] seam only — this module never spawns a subprocess
+//! itself — with the `lladdr ([0-9a-fA-F:]+)` regex, lowercased and stripped
+//! to a 12-hex `hexmac`. Resolution is neighbor-table + filesystem only:
+//! these handlers never touch CockroachDB (spec Decision 4 — the `:25000`
+//! read plane keeps serving under CRDB degradation).
+//!
+//! Normative split (Decision 12): for the four seed files, an existing
+//! `<hexmac>` directory with the requested file missing is an EMPTY 200
+//! (Python `:512` reads `b""` for a missing file via `else b""`). For
+//! `/autoinstall/uaa-config` the same condition is a HARD 404 with an empty
+//! response (Python `:544-548`) — the USB bootstrap must fail loudly at
+//! fetch time, never receive an empty config. No neighbor-table entry, or a
+//! resolved MAC with no `<hexmac>` directory, is a 404 (empty response) for
+//! ALL FIVE endpoints.
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::{
+    extract::{ConnectInfo, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+
+use uaa_core::network::{CommandExecutor, LocalClient};
+
+/// Webroot base (mirrors Python's `CLOUD_INIT_BASE`, `:32`). Only the
+/// production [`default_state`] reads this constant; tests always inject a
+/// tempdir webroot via [`AppState`] directly.
+const CLOUD_INIT_BASE: &str = "/var/www/html/cloud-init";
+
+// ── Pure parity functions ──────────────────────────────────────────────────
+
+/// Parse the `lladdr` MAC out of `ip neigh show` output (Python
+/// `mac_from_neighbor_table`, `:186-194`, regex `:191`). Returns `None` on no
+/// match — callers treat that exactly like a swallowed exception (`:193-194`).
+pub fn mac_from_neighbor_output(out: &str) -> Option<String> {
+    let re = regex::Regex::new(r"lladdr ([0-9a-fA-F:]+)").expect("static regex is valid");
+    re.captures(out).map(|c| c[1].to_lowercase())
+}
+
+/// Strip MAC separators to a bare 12-hex string (mirrors Python `mac_to_hex`,
+/// `:75-76`).
+pub fn mac_to_hex(mac: &str) -> String {
+    mac.to_lowercase().replace([':', '-', '.'], "")
+}
+
+/// Resolve `<webroot>/<hexmac>` for `client_ip` (Python `resolve_cloud_init_dir`,
+/// `:196-202`): run `ip neigh show <client_ip>` through the executor seam
+/// (any executor error — including a timeout or non-zero exit — is swallowed
+/// to `None`, mirroring Python's blanket `except Exception` at `:193`), parse
+/// the MAC, and report whether the per-machine directory exists.
+///
+/// Returns:
+/// - `None` — no MAC resolved (empty `client_ip`, executor error, or no
+///   `lladdr` match).
+/// - `Some((hexmac, None))` — MAC resolved but `<webroot>/<hexmac>` is not a
+///   directory.
+/// - `Some((hexmac, Some(dir)))` — MAC resolved and the directory exists.
+pub async fn resolve_cloud_init_dir(
+    executor: &mut (dyn CommandExecutor + Send),
+    webroot: &Path,
+    client_ip: &str,
+) -> Option<(String, Option<PathBuf>)> {
+    if client_ip.is_empty() {
+        return None;
+    }
+    let out = executor
+        .execute_with_output(&format!("ip neigh show {client_ip}"))
+        .await
+        .ok()?;
+    let mac = mac_from_neighbor_output(&out)?;
+    let hexmac = mac_to_hex(&mac);
+    let dir = webroot.join(&hexmac);
+    Some((hexmac, dir.is_dir().then_some(dir)))
+}
+
+// ── Router state ────────────────────────────────────────────────────────
+
+/// Mints one fresh executor per request. `CommandExecutor::execute_with_output`
+/// takes `&mut self`, so a single shared instance can't safely serve
+/// concurrent requests — the factory sidesteps that without a lock.
+type ExecutorFactory = Arc<dyn Fn() -> Box<dyn CommandExecutor + Send> + Send + Sync>;
+
+/// Router state: webroot base + the executor factory. Tests substitute both
+/// fields — a tempdir webroot and a factory returning a recording
+/// `MockExecutor` clone — so handler logic never touches a live shell or
+/// CockroachDB.
+#[derive(Clone)]
+struct AppState {
+    webroot: Arc<PathBuf>,
+    executor_factory: ExecutorFactory,
+}
+
+/// Production state: real webroot constant + a fresh [`LocalClient`] (already
+/// `CommandExecutor`-typed, `crates/uaa-core/src/network/executor.rs`) per
+/// request — never a subprocess call written in this file.
+fn default_state() -> AppState {
+    AppState {
+        webroot: Arc::new(PathBuf::from(CLOUD_INIT_BASE)),
+        executor_factory: Arc::new(|| Box::new(LocalClient::new()) as Box<dyn CommandExecutor + Send>),
+    }
+}
+
+// ── HTTP helpers ────────────────────────────────────────────────────────
+
+fn empty_404() -> Response {
+    StatusCode::NOT_FOUND.into_response()
+}
+
+fn text_200(payload: Vec<u8>) -> Response {
+    let len = payload.len();
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "text/plain; charset=utf-8".to_string()),
+            (header::CONTENT_LENGTH, len.to_string()),
+        ],
+        payload,
+    )
+        .into_response()
+}
+
+// ── Shared resolution + serve logic ────────────────────────────────────
+
+/// Resolve `client_ip` to a hexmac directory, or return the appropriate 404
+/// (no neighbor entry / no directory registered) as `Err`. Shared by all
+/// five handlers so the DENIED-reason logging (client_ip + hexmac only,
+/// never file contents) lives in one place.
+async fn resolve_or_deny(
+    state: &AppState,
+    client_ip: &str,
+    endpoint: &str,
+) -> Result<(String, PathBuf), Response> {
+    let mut executor = (state.executor_factory)();
+    match resolve_cloud_init_dir(executor.as_mut(), &state.webroot, client_ip).await {
+        None => {
+            tracing::info!(%endpoint, %client_ip, "AUTOINSTALL DENIED - no ARP/NDP neighbor entry");
+            Err(empty_404())
+        }
+        Some((hexmac, None)) => {
+            tracing::info!(%endpoint, %client_ip, %hexmac, "AUTOINSTALL DENIED - no cloud-init dir registered");
+            Err(empty_404())
+        }
+        Some((hexmac, Some(dir))) => Ok((hexmac, dir)),
+    }
+}
+
+/// Serve one of the four cloud-init seed files. A missing file under an
+/// existing hexmac directory is an EMPTY 200 (Decision 12) — never a 404.
+async fn serve_seed_file(state: &AppState, client_ip: &str, filename: &str) -> Response {
+    let (hexmac, dir) = match resolve_or_deny(state, client_ip, filename).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let file_path = dir.join(filename);
+    // empty-200: Decision 12 — a missing seed file under an existing hexmac
+    // directory is served empty (Python `:512`'s `else b""` for a missing file).
+    let payload = if file_path.is_file() {
+        std::fs::read(&file_path).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    tracing::info!(%client_ip, %hexmac, %filename, "AUTOINSTALL served");
+    text_200(payload)
+}
+
+/// Serve `/autoinstall/uaa-config`. Unlike the seed files, a missing
+/// `uaa.yaml` is a HARD 404 (Decision 12, Python `:544-548`) — never an
+/// empty 200 — so the USB bootstrap fails loudly at fetch time instead of
+/// receiving an empty config.
+async fn serve_uaa_config(state: &AppState, client_ip: &str) -> Response {
+    let (hexmac, dir) = match resolve_or_deny(state, client_ip, "uaa-config").await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let file_path = dir.join("uaa.yaml");
+    if !file_path.is_file() {
+        tracing::info!(%client_ip, %hexmac, "UAA-CONFIG DENIED - no uaa.yaml placed");
+        return empty_404();
+    }
+    let payload = std::fs::read(&file_path).unwrap_or_default();
+    tracing::info!(%client_ip, %hexmac, "UAA-CONFIG served");
+    text_200(payload)
+}
+
+// ── Axum handlers (State first, ConnectInfo last — no body extractor on a
+// GET route) ────────────────────────────────────────────────────────────
+
+async fn handle_user_data(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    serve_seed_file(&state, &addr.ip().to_string(), "user-data").await
+}
+
+async fn handle_meta_data(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    serve_seed_file(&state, &addr.ip().to_string(), "meta-data").await
+}
+
+async fn handle_vendor_data(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    serve_seed_file(&state, &addr.ip().to_string(), "vendor-data").await
+}
+
+async fn handle_network_config(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    serve_seed_file(&state, &addr.ip().to_string(), "network-config").await
+}
+
+async fn handle_uaa_config(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    serve_uaa_config(&state, &addr.ip().to_string()).await
+}
+
+fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/autoinstall/user-data", get(handle_user_data))
+        .route("/autoinstall/meta-data", get(handle_meta_data))
+        .route("/autoinstall/vendor-data", get(handle_vendor_data))
+        .route("/autoinstall/network-config", get(handle_network_config))
+        .route("/autoinstall/uaa-config", get(handle_uaa_config))
+        .with_state(state)
+}
+
+/// The seeds sub-router. Merged into `machine_plane::router()` by the
+/// coordinator with `.merge(seeds::router())` (owned by CT-01's `mod.rs` —
+/// never edited here). Each route matches exactly one literal filename, so an
+/// unrecognized `/autoinstall/<other>` path never reaches these handlers.
+/// The listener must be served with
+/// `Router::into_make_service_with_connect_info::<SocketAddr>()` for
+/// `ConnectInfo` to resolve to the real TCP peer address — the Rust
+/// equivalent of Python's `self.client_address[0]`.
+pub fn router() -> Router {
+    build_router(default_state())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use uaa_core::{AutoInstallError, Result as CoreResult};
+
+    /// Recording mock executor: returns pre-loaded output strings keyed by
+    /// the exact command string, or an error when `fail` is set. Mirrors the
+    /// `MockExecutor` idiom in `crates/uaa-core/src/autoinstall/verify.rs`.
+    #[derive(Clone, Default)]
+    struct MockExecutor {
+        responses: HashMap<String, String>,
+        fail: bool,
+    }
+
+    impl MockExecutor {
+        fn new(pairs: &[(&str, &str)]) -> Self {
+            Self {
+                responses: pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+                fail: false,
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                responses: HashMap::new(),
+                fail: true,
+            }
+        }
+
+        fn get(&self, cmd: &str) -> String {
+            self.responses.get(cmd).cloned().unwrap_or_default()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CommandExecutor for MockExecutor {
+        async fn connect(&mut self, _host: &str, _username: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        async fn execute(&mut self, _command: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        async fn execute_with_output(&mut self, command: &str) -> CoreResult<String> {
+            if self.fail {
+                return Err(AutoInstallError::ProcessError {
+                    command: command.to_string(),
+                    exit_code: None,
+                    stderr: "mock executor error".to_string(),
+                });
+            }
+            Ok(self.get(command))
+        }
+        async fn execute_with_error_collection(
+            &mut self,
+            command: &str,
+            _description: &str,
+        ) -> CoreResult<(i32, String, String)> {
+            Ok((0, self.get(command), String::new()))
+        }
+        async fn check_silent(&mut self, command: &str) -> CoreResult<bool> {
+            Ok(!self.get(command).is_empty())
+        }
+        async fn collect_debug_info(&mut self) -> CoreResult<String> {
+            Ok(String::new())
+        }
+        async fn upload_file(&mut self, _local: &str, _remote: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        async fn download_file(&mut self, _remote: &str, _local: &str) -> CoreResult<()> {
+            Ok(())
+        }
+        fn disconnect(&mut self) {}
+    }
+
+    const CLIENT_IP: &str = "172.16.3.92";
+    const REACHABLE: &str = "172.16.3.92 dev eth0 lladdr 6c:4b:90:bc:39:b3 REACHABLE";
+    const HEXMAC: &str = "6c4b90bc39b3";
+
+    fn neigh_cmd() -> String {
+        format!("ip neigh show {CLIENT_IP}")
+    }
+
+    fn client_addr() -> SocketAddr {
+        SocketAddr::from(([172, 16, 3, 92], 54321))
+    }
+
+    fn test_state_with(webroot: PathBuf, mock: MockExecutor) -> AppState {
+        AppState {
+            webroot: Arc::new(webroot),
+            executor_factory: Arc::new(move || Box::new(mock.clone()) as Box<dyn CommandExecutor + Send>),
+        }
+    }
+
+    async fn body_bytes(resp: Response) -> Vec<u8> {
+        axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
+    async fn all_five(state: &AppState) -> Vec<Response> {
+        let addr = client_addr();
+        vec![
+            handle_user_data(State(state.clone()), ConnectInfo(addr)).await,
+            handle_meta_data(State(state.clone()), ConnectInfo(addr)).await,
+            handle_vendor_data(State(state.clone()), ConnectInfo(addr)).await,
+            handle_network_config(State(state.clone()), ConnectInfo(addr)).await,
+            handle_uaa_config(State(state.clone()), ConnectInfo(addr)).await,
+        ]
+    }
+
+    #[test]
+    fn test_router_builds_standalone() {
+        // Constructing the router touches no filesystem/network — only requests do.
+        let _ = router();
+    }
+
+    #[test]
+    fn test_mac_parse_and_hex() {
+        let mac = mac_from_neighbor_output(REACHABLE).unwrap();
+        assert_eq!(mac, "6c:4b:90:bc:39:b3");
+        assert_eq!(mac_to_hex(&mac), HEXMAC);
+    }
+
+    #[tokio::test]
+    async fn test_no_neighbor_entry_404() {
+        let dir = tempfile::tempdir().unwrap();
+        // No `lladdr` in the output -> no MAC resolves.
+        let mock = MockExecutor::new(&[(neigh_cmd().as_str(), "172.16.3.92 dev eth0 FAILED")]);
+        let state = test_state_with(dir.path().to_path_buf(), mock);
+
+        for resp in all_five(&state).await {
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert!(body_bytes(resp).await.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_no_hexmac_dir_404() {
+        let dir = tempfile::tempdir().unwrap();
+        // MAC resolves, but the hexmac directory is never created under `dir`.
+        let mock = MockExecutor::new(&[(neigh_cmd().as_str(), REACHABLE)]);
+        let state = test_state_with(dir.path().to_path_buf(), mock);
+
+        for resp in all_five(&state).await {
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert!(body_bytes(resp).await.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_missing_seed_file_empty_200() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(HEXMAC)).unwrap();
+        let mock = MockExecutor::new(&[(neigh_cmd().as_str(), REACHABLE)]);
+        let state = test_state_with(dir.path().to_path_buf(), mock);
+
+        let resp = handle_user_data(State(state), ConnectInfo(client_addr())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "text/plain; charset=utf-8"
+        );
+        let payload = body_bytes(resp).await;
+        assert_eq!(payload.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_missing_uaa_config_hard_404() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(HEXMAC)).unwrap();
+        let mock = MockExecutor::new(&[(neigh_cmd().as_str(), REACHABLE)]);
+        let state = test_state_with(dir.path().to_path_buf(), mock);
+
+        let resp = handle_uaa_config(State(state), ConnectInfo(client_addr())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(body_bytes(resp).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_present_files_served() {
+        let dir = tempfile::tempdir().unwrap();
+        let hex_dir = dir.path().join(HEXMAC);
+        std::fs::create_dir_all(&hex_dir).unwrap();
+        std::fs::write(hex_dir.join("user-data"), b"#cloud-config\nhostname: foo\n").unwrap();
+        // Placeholder only -- never a real secret in this repo.
+        std::fs::write(hex_dir.join("uaa.yaml"), b"disk_device: REPLACE_AT_PLACE_TIME\n").unwrap();
+        let mock = MockExecutor::new(&[(neigh_cmd().as_str(), REACHABLE)]);
+        let state = test_state_with(dir.path().to_path_buf(), mock);
+
+        let resp = handle_user_data(State(state.clone()), ConnectInfo(client_addr())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_bytes(resp).await, b"#cloud-config\nhostname: foo\n".to_vec());
+
+        let resp = handle_uaa_config(State(state), ConnectInfo(client_addr())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            body_bytes(resp).await,
+            b"disk_device: REPLACE_AT_PLACE_TIME\n".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_executor_error_is_404() {
+        let dir = tempfile::tempdir().unwrap();
+        let mock = MockExecutor::failing();
+        let state = test_state_with(dir.path().to_path_buf(), mock);
+
+        for resp in all_five(&state).await {
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert!(body_bytes(resp).await.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_empty_client_ip_none() {
+        // A synchronous smoke check for the empty-IP guard mentioned in the
+        // brief's edge semantics -- exercised end-to-end via the 404 tests
+        // above (an unmatched neighbor command returns an empty response,
+        // which also has no `lladdr` match).
+        assert!(mac_from_neighbor_output("").is_none());
+    }
+}

--- a/crates/uaa-control/src/saga.rs
+++ b/crates/uaa-control/src/saga.rs
@@ -1,8 +1,1478 @@
 // file: crates/uaa-control/src/saga.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 25f36b48-dfa6-49c2-b30b-46d3fdf8adcb
 // last-edited: 2026-07-10
 
-//! Approve-SAGA orchestration + compensation (saga_log table).
+//! Approve-SAGA orchestration + compensation (`saga_log` table), spec C3.
 //!
-//! STUB — Filled exclusively by control TASK-05 (CT-05).
+//! `ApproveMachine` is a strictly ORDERED, persisted, resumable state machine:
+//!
+//!   1. `WebService.PlaceSeed` + `PlaceIpxe` — inert placement FIRST;
+//!   2. `PxeService.SetupPxe` + `SetBootTarget` — activation LAST (see
+//!      [`SAGA_STEPS`]: a failure between steps leaves the host inert, never
+//!      activated-with-no-seed);
+//!   3. registry `status=approved` + `boot_target` write + audit record.
+//!
+//! Compensation runs the REVERSE order (activation undone before placement).
+//! An unreachable participant during compensation parks the saga in
+//! `compensation_pending` with exponential retry (base 1s, cap 5m, jittered)
+//! — [`SagaState::Compensated`] is written in EXACTLY ONE place in this file
+//! ([`retry_compensation`]'s success arm), and only after every remaining
+//! undo has confirmed `Ok`. Every transition persists to `saga_log` via
+//! [`SagaStore::put`] before the corresponding participant call runs
+//! ([`persist_then`]), so an interrupted saga always resumes by re-running
+//! its next unexecuted (or un-undone) step — never skipping one, and never
+//! double-running one that already reached a terminal per-step state.
+//!
+//! # Coordinator wiring (read before touching any other file)
+//!
+//! This module is purely additive and self-contained; per this task's
+//! coordinator rules it does NOT edit `lib.rs`, `listeners.rs`, `main.rs`, or
+//! any other file. Two things are needed elsewhere once a real deployment
+//! wants this wired up (left as TODOs here, applied by the coordinator):
+//!
+//! - **Startup resume**: `crate::listeners::serve` (or `main.rs`'s `Serve`
+//!   arm) should call [`resume_unfinished`] once, before binding the
+//!   listeners, passing a [`SagaDeps`] built from the REAL `PgSagaStore` +
+//!   `RegistryStore`/`AuditStore` impls + tonic-backed `WebClient`/
+//!   `PxeClient` impls (none of which exist yet — the uaa-web/uaa-pxe gRPC
+//!   clients are a later task, matching the brief's "narrow LOCAL traits"
+//!   instruction). Until those real clients land there is nothing to
+//!   construct a live [`SagaDeps`] from, so no call is added here.
+//! - **[`WebClient`]/[`PxeClient`] unification**: `reinstall.rs` (CT-06,
+//!   same wave) already declares structurally-similar local
+//!   `WebClient`/`PxeClient` traits for the same reason (saga.rs was still a
+//!   header-only stub when CT-06 was authored). TODO(coordinator): once real
+//!   tonic clients exist, decide whether `reinstall.rs` reuses these traits
+//!   (shapes differ slightly — this module's [`WebClient::place_seed`] etc.
+//!   vs. reinstall's `flip_boot_target`-only surface) or both stay separate
+//!   per-module seams. No action is needed here; this module does not import
+//!   from `reinstall.rs` or vice versa.
+//!
+//! # Reuse (do not invent parallels)
+//!
+//! - [`crate::db::SagaRow`] / [`crate::db::SagaState`] (CT-01, `db/mod.rs`) —
+//!   the `saga_log` row type and its `running|done|compensating|compensated|
+//!   compensation_pending` state enum are used AS-IS.
+//! - [`crate::db::registry::RegistryStore`] / `MemRegistryStore` (CT-02,
+//!   merged) — the registry-write step (3) goes through the real trait, not
+//!   a local mock seam.
+//! - [`crate::audit::record`] / [`crate::audit::AuditStore`] (CT-04, merged)
+//!   — the audit record in step (3) goes through the real hash-chained
+//!   store, not a local `AuditSink` stand-in (CT-04 was already merged when
+//!   this task started, so the brief's "if not yet merged" fallback does not
+//!   apply).
+//!
+//! [`WebClient`], [`PxeClient`], and [`SagaStore`] have no CT-01..07 owner
+//! yet (the brief calls for exactly these three local seams), so they are
+//! defined fresh in this file, per the brief.
+
+use std::future::Future;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::audit::{self, AuditStore};
+use crate::db::registry::RegistryStore;
+use crate::db::{BootTarget, MachineStatus, SagaRow, SagaState};
+
+// ── Step model ───────────────────────────────────────────────────────────
+
+/// Per-step lifecycle. `Ok` means the forward action has been confirmed;
+/// `Compensated` means an `Ok` step was later successfully undone.
+/// `Failed` is terminal for that step — the SAGA never retries a forward
+/// step, it compensates everything before it instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepState {
+    Pending,
+    Ok,
+    Failed,
+    Compensated,
+}
+
+/// One entry in the `saga_log.steps` JSONB array.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StepRecord {
+    pub name: String,
+    pub state: StepState,
+}
+
+/// The fixed step order — THIS ARRAY'S ORDER IS THE SAFETY PROPERTY (spec
+/// C3): placement (`place_seed`, `place_ipxe`) runs before activation
+/// (`setup_pxe`, `set_boot_target` — "activation LAST — a failure between
+/// steps leaves the host inert, never activated-with-no-seed",
+/// `docs/specs/constellation-design.md:460`). `registry_approve` (status +
+/// boot_target + audit) runs only after every prior step is confirmed `Ok`.
+/// Nothing in this file reorders or parallelizes this array.
+pub const SAGA_STEPS: [&str; 5] = [
+    "place_seed",
+    "place_ipxe",
+    "setup_pxe",
+    "set_boot_target",
+    "registry_approve",
+];
+
+const IDX_PLACE_SEED: usize = 0;
+const IDX_PLACE_IPXE: usize = 1;
+const IDX_SETUP_PXE: usize = 2;
+const IDX_SET_BOOT_TARGET: usize = 3;
+// Only referenced by `#[cfg(test)]` fixtures that construct a mid-flight
+// `SagaRow` directly (e.g. `test_resume_compensation_pending_retries`); the
+// driver itself reaches this step purely by iterating `SAGA_STEPS`.
+#[cfg(test)]
+const IDX_REGISTRY_APPROVE: usize = 4;
+
+/// Saga `kind` discriminator prefix. The real key for "is there already a
+/// saga for this mac" is `kind`, since the fixed `saga_log` schema (CT-01
+/// migration, not editable by this task) has no separate `target`/`mac`
+/// column — only `saga_id | kind | state | steps | started_at |
+/// finished_at`. Encoding the mac into `kind` keeps duplicate/done lookups a
+/// plain equality match (`get_by_kind`) instead of a JSONB path query.
+const SAGA_KIND_PREFIX: &str = "approve_machine:";
+
+fn saga_kind(mac: &str) -> String {
+    format!("{SAGA_KIND_PREFIX}{mac}")
+}
+
+fn mac_from_kind(kind: &str) -> Result<String> {
+    kind.strip_prefix(SAGA_KIND_PREFIX)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("saga_log row has an unrecognized kind: {kind:?}"))
+}
+
+fn initial_steps() -> Vec<StepRecord> {
+    SAGA_STEPS
+        .iter()
+        .map(|name| StepRecord {
+            name: (*name).to_string(),
+            state: StepState::Pending,
+        })
+        .collect()
+}
+
+fn steps_to_json(steps: &[StepRecord]) -> Result<serde_json::Value> {
+    Ok(serde_json::to_value(steps)?)
+}
+
+fn steps_from_json(value: &serde_json::Value) -> Result<Vec<StepRecord>> {
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Wire-format boot target string projected to both layers and written to
+/// the registry when a machine is approved (spec Decision 13).
+const APPROVED_BOOT_TARGET: &str = "custom-autoinstall";
+
+// ── Outcome ──────────────────────────────────────────────────────────────
+
+/// Result of [`approve_machine`] / one saga's continuation in
+/// [`resume_unfinished`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SagaOutcome {
+    /// All five steps confirmed `Ok`; the host is approved and activated.
+    Done { saga_id: Uuid },
+    /// A step failed and compensation is parked, waiting on an unreachable
+    /// participant. NEVER emitted as a substitute for
+    /// [`SagaOutcome::Compensated`] — see the module-level invariant.
+    CompensationPending { saga_id: Uuid },
+    /// A step failed and every already-completed step has been confirmed
+    /// undone. The host is back to its pre-approval state.
+    Compensated { saga_id: Uuid },
+    /// A typed refusal: a saga for this mac is already `running`,
+    /// `compensating`, or `compensation_pending` — no second saga is started.
+    Refused { saga_id: Uuid, state: SagaState },
+    /// Duplicate `ApproveMachine` for a mac whose saga already reached
+    /// `done` — a no-op success, not an error.
+    AlreadyDone { saga_id: Uuid },
+}
+
+// ── Participant seams (local — the real tonic clients land later) ─────────
+
+/// uaa-web participant. Local stand-in for the not-yet-generated tonic
+/// client (`proto/uaa/web/v1/web.proto`'s `WebService`) — see the
+/// module-level coordinator-wiring note. `flip_boot_target` is part of the
+/// proto surface this trait fronts; `ApproveMachine` itself never calls it
+/// (that is `ReinstallMachine`'s job), but it is included so a future
+/// concrete client only needs ONE `WebClient` impl for every caller in this
+/// crate.
+#[async_trait]
+pub trait WebClient: Send + Sync {
+    /// Place the (non-secret, placeholder-only) autoinstall seed for `mac`.
+    async fn place_seed(&self, mac: &str, payload: &serde_json::Value) -> Result<()>;
+    /// Place the iPXE boot config for `mac`.
+    async fn place_ipxe(&self, mac: &str, payload: &serde_json::Value) -> Result<()>;
+    /// Undo whatever `place_seed`/`place_ipxe` placed for `mac`. Idempotent-
+    /// tolerant: removing an already-removed (or never-placed) host is `Ok`.
+    async fn remove_host(&self, mac: &str) -> Result<()>;
+    /// Flip the iPXE `set menu-default` boot target for `mac` to `target`.
+    /// Unused by [`approve_machine`] (reserved for `ReinstallMachine`).
+    async fn flip_boot_target(&self, mac: &str, target: &str) -> Result<bool>;
+}
+
+/// uaa-pxe participant. Local stand-in for the not-yet-generated tonic
+/// client (`proto/uaa/pxe/v1/pxe.proto`'s `PxeService`) — see the
+/// module-level coordinator-wiring note.
+#[async_trait]
+pub trait PxeClient: Send + Sync {
+    /// Write the per-host `dhcp-hostsdir`/`dhcp-optsdir` files for `mac` and
+    /// verify-reload dnsmasq.
+    async fn setup_pxe(&self, mac: &str) -> Result<()>;
+    /// Set the dnsmasq per-host boot program for `mac` to `target`.
+    async fn set_boot_target(&self, mac: &str, target: &str) -> Result<()>;
+    /// Undo whatever `setup_pxe`/`set_boot_target` activated for `mac`.
+    /// Idempotent-tolerant, same contract as [`WebClient::remove_host`].
+    async fn clear_host(&self, mac: &str) -> Result<()>;
+}
+
+// ── saga_log persistence seam ───────────────────────────────────────────
+
+/// Persistence for `saga_log`. `put` is an upsert keyed by `saga_id`
+/// (unlike the Decision-22 registry tables, `saga_log` is a per-run journal
+/// that MUST be rewritable on every step transition — `DO UPDATE` is
+/// correct here, not a violation of that law).
+#[async_trait]
+pub trait SagaStore: Send + Sync {
+    /// Upsert `row` by `saga_id`.
+    async fn put(&self, row: &SagaRow) -> Result<()>;
+    /// Every row NOT in a terminal state (`done`/`compensated`) — i.e.
+    /// `running`, `compensating`, or `compensation_pending` — for
+    /// [`resume_unfinished`] to continue after a restart.
+    async fn list_unfinished(&self) -> Result<Vec<SagaRow>>;
+    /// The most-recently-written row for an exact `kind` match (used for the
+    /// duplicate-running / done-noop checks in [`approve_machine`]), or
+    /// `None` if no saga has ever run for that kind.
+    async fn get_by_kind(&self, kind: &str) -> Result<Option<SagaRow>>;
+}
+
+/// In-memory [`SagaStore`] for tests (zero network, zero CockroachDB) and
+/// for sibling control-task tests that need a saga journal of their own.
+/// Keeps a full append-only `history` of every `put` in ADDITION to the
+/// current-row map, so tests can assert the exact sequence of persisted
+/// states a saga visited (e.g. "never `compensated` while an undo was
+/// outstanding") — a real CRDB `saga_log` only keeps the latest row per
+/// `saga_id`; this extra bookkeeping is test-only introspection.
+#[derive(Debug, Default)]
+pub struct MemSagaStore {
+    rows: Mutex<std::collections::HashMap<Uuid, SagaRow>>,
+    history: Mutex<Vec<SagaRow>>,
+}
+
+impl MemSagaStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every row ever `put`, in call order. Test-only introspection.
+    pub fn history(&self) -> Vec<SagaRow> {
+        self.history
+            .lock()
+            .expect("MemSagaStore history poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl SagaStore for MemSagaStore {
+    async fn put(&self, row: &SagaRow) -> Result<()> {
+        self.rows
+            .lock()
+            .expect("MemSagaStore rows poisoned")
+            .insert(row.saga_id, row.clone());
+        self.history
+            .lock()
+            .expect("MemSagaStore history poisoned")
+            .push(row.clone());
+        Ok(())
+    }
+
+    async fn list_unfinished(&self) -> Result<Vec<SagaRow>> {
+        Ok(self
+            .rows
+            .lock()
+            .expect("MemSagaStore rows poisoned")
+            .values()
+            .filter(|row| {
+                matches!(
+                    row.state,
+                    SagaState::Running | SagaState::Compensating | SagaState::CompensationPending
+                )
+            })
+            .cloned()
+            .collect())
+    }
+
+    async fn get_by_kind(&self, kind: &str) -> Result<Option<SagaRow>> {
+        Ok(self
+            .history
+            .lock()
+            .expect("MemSagaStore history poisoned")
+            .iter()
+            .rev()
+            .find(|row| row.kind == kind)
+            .cloned())
+    }
+}
+
+// ── PgSagaStore — real tokio-postgres impl (runtime-only; never exercised
+// by `cargo test`, which has no live CockroachDB) ──────────────────────────
+
+pub(crate) const SQL_PUT_SAGA: &str = "\
+    INSERT INTO saga_log (saga_id, kind, state, steps, started_at, finished_at) \
+    VALUES ($1::UUID, $2, $3, $4::JSONB, $5::TIMESTAMPTZ, $6::TIMESTAMPTZ) \
+    ON CONFLICT (saga_id) DO UPDATE SET \
+      state = excluded.state, steps = excluded.steps, finished_at = excluded.finished_at";
+// Deliberately `DO UPDATE`, unlike the insert-if-absent registry tables in
+// `db/registry.rs` (Decision 22 no-clobber law): `saga_log` is a per-run
+// journal keyed by the stable `saga_id`, and every step transition MUST
+// rewrite that same row. Decision 22 scopes the no-clobber law to registry
+// import/rollback tables, not this journal.
+
+pub(crate) const SQL_LIST_UNFINISHED: &str = "\
+    SELECT saga_id::STRING AS saga_id, kind, state, steps::STRING AS steps, \
+           started_at::STRING AS started_at, finished_at::STRING AS finished_at \
+    FROM saga_log WHERE state IN ('running', 'compensating', 'compensation_pending')";
+
+pub(crate) const SQL_GET_BY_KIND: &str = "\
+    SELECT saga_id::STRING AS saga_id, kind, state, steps::STRING AS steps, \
+           started_at::STRING AS started_at, finished_at::STRING AS finished_at \
+    FROM saga_log WHERE kind = $1 ORDER BY started_at DESC LIMIT 1";
+
+/// Real [`SagaStore`]: tokio-postgres against CockroachDB. Constructed only
+/// at runtime; unit tests never build it (no live database in the test path).
+pub struct PgSagaStore {
+    client: tokio_postgres::Client,
+}
+
+impl PgSagaStore {
+    pub fn new(client: tokio_postgres::Client) -> Self {
+        Self { client }
+    }
+}
+
+fn row_to_saga(row: &tokio_postgres::Row) -> Result<SagaRow> {
+    let saga_id_text: String = row.get("saga_id");
+    let steps_text: String = row.get("steps");
+    Ok(SagaRow {
+        saga_id: Uuid::parse_str(&saga_id_text)?,
+        kind: row.get("kind"),
+        state: SagaState::from(row.get::<_, String>("state")),
+        steps: serde_json::from_str(&steps_text)?,
+        started_at: row.get("started_at"),
+        finished_at: row.get("finished_at"),
+    })
+}
+
+#[async_trait]
+impl SagaStore for PgSagaStore {
+    async fn put(&self, row: &SagaRow) -> Result<()> {
+        let saga_id_text = row.saga_id.to_string();
+        let state_text: String = row.state.clone().into();
+        let steps_text = serde_json::to_string(&row.steps)?;
+        self.client
+            .execute(
+                SQL_PUT_SAGA,
+                &[
+                    &saga_id_text,
+                    &row.kind,
+                    &state_text,
+                    &steps_text,
+                    &row.started_at,
+                    &row.finished_at,
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn list_unfinished(&self) -> Result<Vec<SagaRow>> {
+        let rows = self.client.query(SQL_LIST_UNFINISHED, &[]).await?;
+        rows.iter().map(row_to_saga).collect()
+    }
+
+    async fn get_by_kind(&self, kind: &str) -> Result<Option<SagaRow>> {
+        let row = self.client.query_opt(SQL_GET_BY_KIND, &[&kind]).await?;
+        row.as_ref().map(row_to_saga).transpose()
+    }
+}
+
+// ── Backoff / jitter / sleep seams ──────────────────────────────────────
+
+/// Exponential backoff schedule for compensation retries: `base` (1s),
+/// doubling per attempt, capped at `cap` (5m). `max_attempts` bounds the
+/// retry loop so tests can drive a deterministic, finite number of passes
+/// without ever sleeping in real time; production callers leave it `None`
+/// (retry forever — if the process dies first, [`resume_unfinished`]
+/// re-enters the same loop from `saga_log` after restart, so "forever" never
+/// means "silently gives up").
+#[derive(Debug, Clone)]
+pub struct Backoff {
+    pub base: Duration,
+    pub cap: Duration,
+    pub max_attempts: Option<u32>,
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self {
+            base: Duration::from_secs(1),
+            cap: Duration::from_secs(300),
+            max_attempts: None,
+        }
+    }
+}
+
+/// Pure backoff schedule (no jitter): `base * 2^attempt`, capped at `cap`. A
+/// pure function so tests can assert the schedule without sleeping.
+pub fn backoff_delay(attempt: u32, backoff: &Backoff) -> Duration {
+    let multiplier = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+    let secs = backoff.base.as_secs().saturating_mul(multiplier);
+    Duration::from_secs(secs).min(backoff.cap)
+}
+
+/// Jitter seam applied on top of [`backoff_delay`]. Production uses
+/// [`RandJitter`]; tests use a fixed/deterministic impl so retry timing
+/// assertions are exact.
+pub trait Jitter: Send + Sync {
+    fn apply(&self, base: Duration) -> Duration;
+}
+
+/// Production [`Jitter`]: scales the delay by a uniform random factor in
+/// `[0.5, 1.0)` (full jitter would risk a zero-length delay hot loop).
+pub struct RandJitter;
+
+impl Jitter for RandJitter {
+    fn apply(&self, base: Duration) -> Duration {
+        use rand::Rng;
+        let factor: f64 = rand::thread_rng().gen_range(0.5..1.0);
+        Duration::from_secs_f64(base.as_secs_f64() * factor)
+    }
+}
+
+/// Deterministic [`Jitter`] for tests: returns `base` unchanged.
+pub struct NoJitter;
+
+impl Jitter for NoJitter {
+    fn apply(&self, base: Duration) -> Duration {
+        base
+    }
+}
+
+/// Clock/sleep seam so tests never really sleep. Mirrors the same pattern
+/// used by `uaa-core::pki`'s enrollment poll loop and `reinstall.rs`'s
+/// `Clock` — each module owns its own tiny instance rather than sharing one
+/// across unrelated domains.
+#[async_trait]
+pub trait Sleeper: Send + Sync {
+    async fn sleep(&self, duration: Duration);
+}
+
+/// Production [`Sleeper`] backed by `tokio::time::sleep`.
+pub struct TokioSleeper;
+
+#[async_trait]
+impl Sleeper for TokioSleeper {
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+}
+
+// ── Dependency bundle ────────────────────────────────────────────────────
+
+/// Everything [`approve_machine`] / [`resume_unfinished`] depend on, as
+/// trait objects so tests inject mocks. No live gRPC client or database
+/// connection is ever constructed by this file (see the acceptance
+/// criteria's `grep -n "7445\|7446\|tonic::transport"` check — this module
+/// never does either).
+pub struct SagaDeps<'a> {
+    pub web: &'a dyn WebClient,
+    pub pxe: &'a dyn PxeClient,
+    pub saga_store: &'a dyn SagaStore,
+    pub registry: &'a dyn RegistryStore,
+    pub audit: &'a dyn AuditStore,
+    pub sleeper: &'a dyn Sleeper,
+    pub jitter: &'a dyn Jitter,
+    pub backoff: Backoff,
+}
+
+// ── persist_then: the ONE transition helper ─────────────────────────────
+
+/// Write `row` to `saga_log` FIRST, then run `action`. A crash between the
+/// persist and the action simply re-runs the acted step on the next resume
+/// (safe: every [`WebClient`]/[`PxeClient`] call in this SAGA is
+/// idempotent-tolerant per the spec's edge semantics) — it can never SKIP a
+/// step whose start was already durably recorded. Every state transition in
+/// this file goes through this one helper.
+async fn persist_then<'a, F, Fut, T>(deps: &SagaDeps<'a>, row: &SagaRow, action: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    deps.saga_store.put(row).await?;
+    action().await
+}
+
+// ── Forward driver ───────────────────────────────────────────────────────
+
+fn placement_payload(mac: &str) -> serde_json::Value {
+    // Non-secret fields + placeholders ONLY (spec `WebService.PlaceSeed`
+    // comment: "non-secret fields + placeholders ONLY") — no real secret
+    // material is ever constructed here.
+    serde_json::json!({ "mac": mac, "luks_key": "REPLACE_AT_PLACE_TIME" })
+}
+
+async fn registry_approve(deps: &SagaDeps<'_>, mac: &str) -> Result<()> {
+    // Registry write (status=approved) + boot_target write + audit record.
+    // The `RegistryStore` trait (CT-02) exposes single-field mutators, not
+    // one atomic multi-field write, so a failure between these two calls
+    // (status written, boot_target not yet) is a known narrow gap this file
+    // cannot close without editing `db/registry.rs` (out of scope for this
+    // task — CT-05 is `saga.rs`-exclusive). `update_machine_status` runs
+    // first so a `boot_target` failure never leaves an unapproved host
+    // "activated" by boot_target alone.
+    deps.registry
+        .update_machine_status(mac, MachineStatus::Approved, Some(now_rfc3339()))
+        .await?;
+    deps.registry
+        .set_boot_target(mac, BootTarget::from(APPROVED_BOOT_TARGET.to_string()))
+        .await?;
+    audit::record(
+        deps.audit,
+        "system",
+        "system",
+        "approve_machine",
+        Some(mac.to_string()),
+        "approved",
+        Some(serde_json::json!({ "boot_target": APPROVED_BOOT_TARGET })),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_step(deps: &SagaDeps<'_>, mac: &str, name: &str) -> Result<()> {
+    match name {
+        "place_seed" => deps.web.place_seed(mac, &placement_payload(mac)).await,
+        "place_ipxe" => deps.web.place_ipxe(mac, &placement_payload(mac)).await,
+        "setup_pxe" => deps.pxe.setup_pxe(mac).await,
+        "set_boot_target" => deps.pxe.set_boot_target(mac, APPROVED_BOOT_TARGET).await,
+        "registry_approve" => registry_approve(deps, mac).await,
+        other => Err(anyhow::anyhow!("unknown saga step: {other}")),
+    }
+}
+
+/// Drive `row` forward from its first non-`Ok` step through `registry_approve`
+/// (steps already `Ok` — the resume case — are skipped, never re-run).
+/// `set_boot_target` (activation) NEVER runs before both `place_seed` and
+/// `place_ipxe` (placement) are confirmed `Ok`: the loop is strictly
+/// sequential over [`SAGA_STEPS`], no reordering, no parallel join. On the
+/// first step failure, everything already `Ok` is compensated via
+/// [`retry_compensation`] and this function returns THAT outcome.
+async fn run_forward(deps: &SagaDeps<'_>, row: &mut SagaRow, mac: &str) -> Result<SagaOutcome> {
+    let mut steps = steps_from_json(&row.steps)?;
+
+    for (i, step_name) in SAGA_STEPS.iter().enumerate() {
+        let step_name: &str = step_name;
+        if steps[i].state == StepState::Ok {
+            continue;
+        }
+
+        row.steps = steps_to_json(&steps)?;
+        let result = persist_then(deps, row, || run_step(deps, mac, step_name)).await;
+
+        match result {
+            Ok(()) => {
+                steps[i].state = StepState::Ok;
+                row.steps = steps_to_json(&steps)?;
+                deps.saga_store.put(row).await?;
+            }
+            Err(_step_err) => {
+                steps[i].state = StepState::Failed;
+                row.steps = steps_to_json(&steps)?;
+                row.state = SagaState::Compensating;
+                deps.saga_store.put(row).await?;
+                return retry_compensation(deps, row).await;
+            }
+        }
+    }
+
+    row.state = SagaState::Done;
+    row.finished_at = Some(now_rfc3339());
+    deps.saga_store.put(row).await?;
+    Ok(SagaOutcome::Done {
+        saga_id: row.saga_id,
+    })
+}
+
+// ── Compensation ─────────────────────────────────────────────────────────
+
+enum CompensationPassResult {
+    Compensated,
+    Pending,
+}
+
+/// One pass of reverse-order undo. Compensation is phase-granular, not
+/// per-step, because the participant seams only expose ONE undo call per
+/// phase ([`PxeClient::clear_host`] for activation, [`WebClient::remove_host`]
+/// for placement) — matching the brief's mapping: step-3 (registry) failure
+/// compensates activation THEN placement; step-2 (activation) failure
+/// compensates whatever activated THEN placement; step-1 (placement)
+/// failure just removes whatever placed (no `clear_host` call at all, since
+/// activation never started). Each already-`Compensated` phase is skipped on
+/// retry (recomputed fresh from the persisted step states every pass), so a
+/// partially-successful pass never re-issues a call that already succeeded.
+async fn attempt_compensation_pass(
+    deps: &SagaDeps<'_>,
+    row: &mut SagaRow,
+) -> Result<CompensationPassResult> {
+    let mac = mac_from_kind(&row.kind)?;
+    let mut steps = steps_from_json(&row.steps)?;
+
+    let activation_ok = steps[IDX_SETUP_PXE].state == StepState::Ok
+        || steps[IDX_SET_BOOT_TARGET].state == StepState::Ok;
+    if activation_ok {
+        let result = persist_then(deps, row, || deps.pxe.clear_host(&mac)).await;
+        match result {
+            Ok(()) => {
+                if steps[IDX_SETUP_PXE].state == StepState::Ok {
+                    steps[IDX_SETUP_PXE].state = StepState::Compensated;
+                }
+                if steps[IDX_SET_BOOT_TARGET].state == StepState::Ok {
+                    steps[IDX_SET_BOOT_TARGET].state = StepState::Compensated;
+                }
+                row.steps = steps_to_json(&steps)?;
+            }
+            Err(_) => return Ok(CompensationPassResult::Pending),
+        }
+    }
+
+    let placement_ok = steps[IDX_PLACE_SEED].state == StepState::Ok
+        || steps[IDX_PLACE_IPXE].state == StepState::Ok;
+    if placement_ok {
+        let result = persist_then(deps, row, || deps.web.remove_host(&mac)).await;
+        match result {
+            Ok(()) => {
+                if steps[IDX_PLACE_SEED].state == StepState::Ok {
+                    steps[IDX_PLACE_SEED].state = StepState::Compensated;
+                }
+                if steps[IDX_PLACE_IPXE].state == StepState::Ok {
+                    steps[IDX_PLACE_IPXE].state = StepState::Compensated;
+                }
+                row.steps = steps_to_json(&steps)?;
+            }
+            Err(_) => return Ok(CompensationPassResult::Pending),
+        }
+    }
+
+    Ok(CompensationPassResult::Compensated)
+}
+
+/// Retry compensation passes with exponential backoff until every step is
+/// confirmed undone (`Compensated`), or `deps.backoff.max_attempts` is
+/// exhausted (test-only bound; production leaves it unbounded and relies on
+/// [`resume_unfinished`] to keep trying after a restart).
+///
+/// INVARIANT (grep-checkable): the only `row.state = SagaState::Compensated`
+/// assignment in this file is in the `CompensationPassResult::Compensated`
+/// arm below, AFTER `attempt_compensation_pass` has reported every
+/// remaining undo as `Ok`. Every other exit from this function persists
+/// `SagaState::CompensationPending` — never `Compensated` — so a saga is
+/// NEVER falsely marked `compensated` while any undo is outstanding.
+async fn retry_compensation(deps: &SagaDeps<'_>, row: &mut SagaRow) -> Result<SagaOutcome> {
+    let mut attempt: u32 = 0;
+    loop {
+        match attempt_compensation_pass(deps, row).await? {
+            CompensationPassResult::Compensated => {
+                row.state = SagaState::Compensated;
+                row.finished_at = Some(now_rfc3339());
+                deps.saga_store.put(row).await?;
+                return Ok(SagaOutcome::Compensated {
+                    saga_id: row.saga_id,
+                });
+            }
+            CompensationPassResult::Pending => {
+                row.state = SagaState::CompensationPending;
+                deps.saga_store.put(row).await?;
+
+                let exhausted =
+                    matches!(deps.backoff.max_attempts, Some(max) if attempt + 1 >= max);
+                if exhausted {
+                    return Ok(SagaOutcome::CompensationPending {
+                        saga_id: row.saga_id,
+                    });
+                }
+
+                let delay = deps.jitter.apply(backoff_delay(attempt, &deps.backoff));
+                deps.sleeper.sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+// ── Public entrypoints ───────────────────────────────────────────────────
+
+/// Drive the `ApproveMachine` SAGA for `mac` per spec C3. Refuses a second
+/// concurrent saga for the same mac (`running`/`compensating`/
+/// `compensation_pending` → [`SagaOutcome::Refused`]); a prior `done` saga is
+/// a no-op success (`AlreadyDone`); a prior `compensated` (fully rolled
+/// back) saga does not block a fresh attempt.
+pub async fn approve_machine(deps: &SagaDeps<'_>, mac: &str) -> Result<SagaOutcome> {
+    let kind = saga_kind(mac);
+
+    if let Some(existing) = deps.saga_store.get_by_kind(&kind).await? {
+        match &existing.state {
+            SagaState::Running | SagaState::Compensating | SagaState::CompensationPending => {
+                return Ok(SagaOutcome::Refused {
+                    saga_id: existing.saga_id,
+                    state: existing.state.clone(),
+                });
+            }
+            SagaState::Done => {
+                return Ok(SagaOutcome::AlreadyDone {
+                    saga_id: existing.saga_id,
+                });
+            }
+            SagaState::Compensated | SagaState::Unknown(_) => {
+                // A prior attempt fully rolled back (or the row is from an
+                // unrecognized legacy state) — start a fresh saga below.
+            }
+        }
+    }
+
+    let mut row = SagaRow {
+        saga_id: Uuid::new_v4(),
+        kind,
+        state: SagaState::Running,
+        steps: steps_to_json(&initial_steps())?,
+        started_at: Some(now_rfc3339()),
+        finished_at: None,
+    };
+    deps.saga_store.put(&row).await?;
+
+    run_forward(deps, &mut row, mac).await
+}
+
+/// Resume every non-terminal `saga_log` row after a restart: `running`
+/// continues from its first non-`Ok` step (via [`run_forward`], which
+/// naturally skips already-`Ok` steps); `compensating`/`compensation_pending`
+/// re-enter the compensation retry loop (via [`retry_compensation`], which
+/// naturally skips already-`Compensated` phases). Called once from the
+/// `serve` startup path — see the module-level coordinator-wiring note for
+/// why that one-line call is not added by this file.
+pub async fn resume_unfinished(deps: &SagaDeps<'_>) -> Result<Vec<SagaOutcome>> {
+    let rows = deps.saga_store.list_unfinished().await?;
+    let mut outcomes = Vec::with_capacity(rows.len());
+
+    for mut row in rows {
+        let mac = mac_from_kind(&row.kind)?;
+        let outcome = match &row.state {
+            SagaState::Running => run_forward(deps, &mut row, &mac).await?,
+            SagaState::Compensating | SagaState::CompensationPending => {
+                retry_compensation(deps, &mut row).await?
+            }
+            SagaState::Done | SagaState::Compensated | SagaState::Unknown(_) => continue,
+        };
+        outcomes.push(outcome);
+    }
+
+    Ok(outcomes)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::MemAuditStore;
+    use crate::db::registry::MemRegistryStore;
+    use crate::db::{BootTarget as DbBootTarget, MachineRow, MachineStatus as DbMachineStatus};
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    // ── Shared call-order log ───────────────────────────────────────────
+
+    #[derive(Debug, Default)]
+    struct CallLog(Mutex<Vec<&'static str>>);
+
+    impl CallLog {
+        fn push(&self, call: &'static str) {
+            self.0.lock().unwrap().push(call);
+        }
+        fn snapshot(&self) -> Vec<&'static str> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    /// Pops the next scripted result off `queue`; an empty queue defaults to
+    /// `Ok(())` (so most tests only need to script the failures they care
+    /// about).
+    fn next_result(queue: &Mutex<VecDeque<bool>>) -> Result<()> {
+        let ok = queue.lock().unwrap().pop_front().unwrap_or(true);
+        if ok {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("mock participant failure"))
+        }
+    }
+
+    // ── Mock WebClient / PxeClient ───────────────────────────────────────
+
+    #[derive(Default)]
+    struct MockParticipants {
+        log: Arc<CallLog>,
+        place_seed: Mutex<VecDeque<bool>>,
+        place_ipxe: Mutex<VecDeque<bool>>,
+        remove_host: Mutex<VecDeque<bool>>,
+        setup_pxe: Mutex<VecDeque<bool>>,
+        set_boot_target: Mutex<VecDeque<bool>>,
+        clear_host: Mutex<VecDeque<bool>>,
+    }
+
+    impl MockParticipants {
+        fn new(log: Arc<CallLog>) -> Self {
+            Self {
+                log,
+                ..Default::default()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl WebClient for MockParticipants {
+        async fn place_seed(&self, _mac: &str, _payload: &serde_json::Value) -> Result<()> {
+            self.log.push("place_seed");
+            next_result(&self.place_seed)
+        }
+        async fn place_ipxe(&self, _mac: &str, _payload: &serde_json::Value) -> Result<()> {
+            self.log.push("place_ipxe");
+            next_result(&self.place_ipxe)
+        }
+        async fn remove_host(&self, _mac: &str) -> Result<()> {
+            self.log.push("remove_host");
+            next_result(&self.remove_host)
+        }
+        async fn flip_boot_target(&self, _mac: &str, _target: &str) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    #[async_trait]
+    impl PxeClient for MockParticipants {
+        async fn setup_pxe(&self, _mac: &str) -> Result<()> {
+            self.log.push("setup_pxe");
+            next_result(&self.setup_pxe)
+        }
+        async fn set_boot_target(&self, _mac: &str, _target: &str) -> Result<()> {
+            self.log.push("set_boot_target");
+            next_result(&self.set_boot_target)
+        }
+        async fn clear_host(&self, _mac: &str) -> Result<()> {
+            self.log.push("clear_host");
+            next_result(&self.clear_host)
+        }
+    }
+
+    // ── Registry wrapper: logs "registry_approve" + optional fail-injection ─
+
+    struct RecordingRegistry {
+        inner: MemRegistryStore,
+        log: Arc<CallLog>,
+        fail_status_update: Mutex<VecDeque<bool>>,
+    }
+
+    impl RecordingRegistry {
+        fn new(log: Arc<CallLog>) -> Self {
+            Self {
+                inner: MemRegistryStore::new(),
+                log,
+                fail_status_update: Mutex::new(VecDeque::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryStore for RecordingRegistry {
+        async fn get_machine(&self, mac: &str) -> Result<Option<MachineRow>> {
+            self.inner.get_machine(mac).await
+        }
+        async fn list_machines(&self) -> Result<Vec<MachineRow>> {
+            self.inner.list_machines().await
+        }
+        async fn insert_machine_if_absent(&self, row: MachineRow) -> Result<bool> {
+            self.inner.insert_machine_if_absent(row).await
+        }
+        async fn update_machine_status(
+            &self,
+            mac: &str,
+            status: DbMachineStatus,
+            approved_at: Option<String>,
+        ) -> Result<()> {
+            self.log.push("registry_approve");
+            next_result(&self.fail_status_update)?;
+            self.inner
+                .update_machine_status(mac, status, approved_at)
+                .await
+        }
+        async fn touch_last_seen(&self, mac: &str, ip: Option<String>) -> Result<()> {
+            self.inner.touch_last_seen(mac, ip).await
+        }
+        async fn set_boot_target(&self, mac: &str, boot_target: DbBootTarget) -> Result<()> {
+            self.inner.set_boot_target(mac, boot_target).await
+        }
+        async fn list_yubikeys(&self) -> Result<Vec<crate::db::YubikeyRow>> {
+            self.inner.list_yubikeys().await
+        }
+        async fn insert_yubikey_if_absent(&self, row: crate::db::YubikeyRow) -> Result<bool> {
+            self.inner.insert_yubikey_if_absent(row).await
+        }
+        async fn list_tang_servers(&self) -> Result<Vec<crate::db::TangServerRow>> {
+            self.inner.list_tang_servers().await
+        }
+        async fn upsert_tang_server(&self, row: crate::db::TangServerRow) -> Result<()> {
+            self.inner.upsert_tang_server(row).await
+        }
+        async fn insert_tang_if_absent(&self, row: crate::db::TangServerRow) -> Result<bool> {
+            self.inner.insert_tang_if_absent(row).await
+        }
+        async fn insert_luks_credential(&self, row: crate::db::LuksCredentialRow) -> Result<()> {
+            self.inner.insert_luks_credential(row).await
+        }
+        async fn list_luks_credentials(
+            &self,
+            mac: &str,
+        ) -> Result<Vec<crate::db::LuksCredentialRow>> {
+            self.inner.list_luks_credentials(mac).await
+        }
+        async fn revoke_luks_credential(&self, id: Uuid) -> Result<()> {
+            self.inner.revoke_luks_credential(id).await
+        }
+    }
+
+    // ── NoopSleeper: records requested durations, never actually waits ────
+
+    #[derive(Default)]
+    struct NoopSleeper(Mutex<Vec<Duration>>);
+
+    #[async_trait]
+    impl Sleeper for NoopSleeper {
+        async fn sleep(&self, duration: Duration) {
+            self.0.lock().unwrap().push(duration);
+            // No real sleep: this is exactly the injectable-clock seam the
+            // brief calls for so tests never sleep in real time.
+        }
+    }
+
+    // ── Test fixture ────────────────────────────────────────────────────
+
+    const MAC: &str = "aa:bb:cc:dd:ee:ff";
+
+    fn seed_machine_row() -> MachineRow {
+        MachineRow {
+            mac: MAC.to_string(),
+            hostname: "h1".into(),
+            ip: None,
+            r#type: "lenovo".into(),
+            status: DbMachineStatus::Pending,
+            boot_target: DbBootTarget::LocalDisk,
+            tpm_ek: None,
+            registered_at: None,
+            approved_at: None,
+            last_seen: None,
+            last_ip: None,
+            installed_at: None,
+            last_install_status: None,
+            updated_at: None,
+        }
+    }
+
+    struct Fixture {
+        log: Arc<CallLog>,
+        participants: MockParticipants,
+        saga_store: MemSagaStore,
+        registry: RecordingRegistry,
+        audit: MemAuditStore,
+        sleeper: NoopSleeper,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let log = Arc::new(CallLog::default());
+            Self {
+                participants: MockParticipants::new(log.clone()),
+                saga_store: MemSagaStore::new(),
+                registry: RecordingRegistry::new(log.clone()),
+                audit: MemAuditStore::new(),
+                sleeper: NoopSleeper::default(),
+                log,
+            }
+        }
+
+        fn deps(&self, max_attempts: Option<u32>) -> SagaDeps<'_> {
+            SagaDeps {
+                web: &self.participants,
+                pxe: &self.participants,
+                saga_store: &self.saga_store,
+                registry: &self.registry,
+                audit: &self.audit,
+                sleeper: &self.sleeper,
+                jitter: &NoJitter,
+                backoff: Backoff {
+                    base: Duration::from_millis(1),
+                    cap: Duration::from_millis(10),
+                    max_attempts,
+                },
+            }
+        }
+    }
+
+    /// The most-recently-persisted row for `mac`, via [`MemSagaStore::history`].
+    fn latest_row(store: &MemSagaStore, mac: &str) -> SagaRow {
+        store
+            .history()
+            .into_iter()
+            .rev()
+            .find(|r| r.kind == saga_kind(mac))
+            .expect("saga row present")
+    }
+
+    // ── Ordering (the safety property) ───────────────────────────────────
+
+    #[tokio::test]
+    async fn test_happy_path_order() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        let deps = fx.deps(Some(5));
+
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        assert!(matches!(outcome, SagaOutcome::Done { .. }), "{outcome:?}");
+        assert_eq!(
+            fx.log.snapshot(),
+            vec![
+                "place_seed",
+                "place_ipxe",
+                "setup_pxe",
+                "set_boot_target",
+                "registry_approve",
+            ],
+            "a fully healthy approve flows through every guard to done \
+             (anti-over-suppression: the ordering machinery does not block \
+             or reorder the legitimate flow)"
+        );
+
+        let machine = fx.registry.get_machine(MAC).await.unwrap().unwrap();
+        assert_eq!(machine.status, DbMachineStatus::Approved);
+        assert_eq!(machine.boot_target, DbBootTarget::CustomAutoinstall);
+        assert_eq!(fx.audit.list_events(0).await.unwrap().len(), 1);
+
+        let row = latest_row(&fx.saga_store, MAC);
+        assert_eq!(row.state, SagaState::Done);
+    }
+
+    #[tokio::test]
+    async fn test_activation_never_before_placement() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        fx.participants
+            .place_ipxe
+            .lock()
+            .unwrap()
+            .push_back(false); // place_ipxe fails
+        let deps = fx.deps(Some(5));
+
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        assert!(
+            matches!(outcome, SagaOutcome::Compensated { .. }),
+            "{outcome:?}"
+        );
+        let calls = fx.log.snapshot();
+        assert!(
+            !calls.contains(&"setup_pxe") && !calls.contains(&"set_boot_target"),
+            "activation must never run after a placement failure: {calls:?}"
+        );
+        assert!(
+            !calls.contains(&"registry_approve"),
+            "registry must never be approved after a placement failure: {calls:?}"
+        );
+        // step-1 partial failure: place_seed succeeded (Ok), place_ipxe
+        // failed — only remove_host undoes it, no clear_host (activation
+        // never started).
+        assert_eq!(
+            calls,
+            vec!["place_seed", "place_ipxe", "remove_host"],
+            "{calls:?}"
+        );
+    }
+
+    // ── Compensation mapping ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_step2_failure_compensates_reverse() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        fx.participants
+            .set_boot_target
+            .lock()
+            .unwrap()
+            .push_back(false); // set_boot_target (activation) fails
+        let deps = fx.deps(Some(5));
+
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        assert!(
+            matches!(outcome, SagaOutcome::Compensated { .. }),
+            "{outcome:?}"
+        );
+        let calls = fx.log.snapshot();
+        assert_eq!(
+            calls,
+            vec![
+                "place_seed",
+                "place_ipxe",
+                "setup_pxe",
+                "set_boot_target",
+                "clear_host",
+                "remove_host",
+            ],
+            "undo order must be exactly [clear_host, remove_host]: {calls:?}"
+        );
+
+        let machine = fx.registry.get_machine(MAC).await.unwrap().unwrap();
+        assert_eq!(
+            machine.status,
+            DbMachineStatus::Pending,
+            "registry must NOT be approved"
+        );
+        assert_eq!(fx.audit.list_events(0).await.unwrap().len(), 0);
+
+        let row = latest_row(&fx.saga_store, MAC);
+        assert_eq!(row.state, SagaState::Compensated);
+    }
+
+    #[tokio::test]
+    async fn test_step3_registry_failure_compensates_both_phases() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        fx.registry
+            .fail_status_update
+            .lock()
+            .unwrap()
+            .push_back(false); // registry_approve fails
+        let deps = fx.deps(Some(5));
+
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        assert!(
+            matches!(outcome, SagaOutcome::Compensated { .. }),
+            "{outcome:?}"
+        );
+        let calls = fx.log.snapshot();
+        assert_eq!(
+            calls,
+            vec![
+                "place_seed",
+                "place_ipxe",
+                "setup_pxe",
+                "set_boot_target",
+                "registry_approve",
+                "clear_host",
+                "remove_host",
+            ],
+            "step-3 failure compensates 2 (activation) then 1 (placement): {calls:?}"
+        );
+    }
+
+    // ── Never falsely compensated ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_unreachable_compensation_parks_pending() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        fx.participants
+            .set_boot_target
+            .lock()
+            .unwrap()
+            .push_back(false);
+        {
+            let mut q = fx.participants.clear_host.lock().unwrap();
+            q.push_back(false);
+            q.push_back(false);
+            q.push_back(false);
+            q.push_back(true);
+        }
+        let deps = fx.deps(Some(10));
+
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        assert!(
+            matches!(outcome, SagaOutcome::Compensated { .. }),
+            "{outcome:?}"
+        );
+
+        let history = fx.saga_store.history();
+        let states: Vec<SagaState> = history.iter().map(|r| r.state.clone()).collect();
+        let last = states.last().cloned().unwrap();
+        assert_eq!(last, SagaState::Compensated);
+
+        let first_compensated_idx = states
+            .iter()
+            .position(|s| *s == SagaState::Compensated)
+            .unwrap();
+        assert_eq!(
+            first_compensated_idx,
+            states.len() - 1,
+            "Compensated must be the LAST and ONLY compensated-terminal state written"
+        );
+        let pending_count = states
+            .iter()
+            .filter(|s| **s == SagaState::CompensationPending)
+            .count();
+        assert!(
+            pending_count >= 3,
+            "must have visited compensation_pending across retries: {states:?}"
+        );
+        // NEVER falsely marked compensated: every entry strictly before the
+        // final one must be something other than Compensated.
+        assert!(
+            states[..states.len() - 1]
+                .iter()
+                .all(|s| *s != SagaState::Compensated),
+            "compensated written only once, at the very end: {states:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_never_falsely_compensated() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        fx.participants
+            .set_boot_target
+            .lock()
+            .unwrap()
+            .push_back(false);
+        // clear_host fails FOREVER — bounded test iterations via max_attempts.
+        {
+            let mut q = fx.participants.clear_host.lock().unwrap();
+            for _ in 0..20 {
+                q.push_back(false);
+            }
+        }
+        let deps = fx.deps(Some(5)); // bounded: exactly 5 compensation attempts
+
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        assert!(
+            matches!(outcome, SagaOutcome::CompensationPending { .. }),
+            "{outcome:?}"
+        );
+
+        let history = fx.saga_store.history();
+        assert!(
+            history.iter().all(|r| r.state != SagaState::Compensated),
+            "must NEVER be marked compensated while an undo is outstanding: {:?}",
+            history
+                .iter()
+                .map(|r| r.state.clone())
+                .collect::<Vec<_>>()
+        );
+        let row = latest_row(&fx.saga_store, MAC);
+        assert_eq!(
+            row.state,
+            SagaState::CompensationPending,
+            "final persisted state must be compensation_pending, not compensated"
+        );
+        // remove_host must never be called: activation compensation never
+        // succeeded, so placement compensation never even starts.
+        assert!(!fx.log.snapshot().contains(&"remove_host"));
+    }
+
+    // ── Resume ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_resume_running_continues() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+
+        let mut steps = initial_steps();
+        steps[IDX_PLACE_SEED].state = StepState::Ok;
+        steps[IDX_PLACE_IPXE].state = StepState::Ok;
+        let row = SagaRow {
+            saga_id: Uuid::new_v4(),
+            kind: saga_kind(MAC),
+            state: SagaState::Running,
+            steps: steps_to_json(&steps).unwrap(),
+            started_at: Some(now_rfc3339()),
+            finished_at: None,
+        };
+        fx.saga_store.put(&row).await.unwrap();
+
+        let deps = fx.deps(Some(5));
+        let outcomes = resume_unfinished(&deps).await.unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(outcomes[0], SagaOutcome::Done { .. }));
+
+        let calls = fx.log.snapshot();
+        assert!(
+            !calls.contains(&"place_seed") && !calls.contains(&"place_ipxe"),
+            "already-ok steps must not re-run: {calls:?}"
+        );
+        assert_eq!(
+            calls,
+            vec!["setup_pxe", "set_boot_target", "registry_approve"],
+            "only steps 3..5 execute: {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resume_compensation_pending_retries() {
+        let fx = Fixture::new();
+        fx.registry
+            .inner
+            .insert_machine_if_absent(seed_machine_row())
+            .await
+            .unwrap();
+        {
+            let mut q = fx.participants.clear_host.lock().unwrap();
+            q.push_back(false);
+            q.push_back(true);
+        }
+
+        let mut steps = initial_steps();
+        steps[IDX_PLACE_SEED].state = StepState::Ok;
+        steps[IDX_PLACE_IPXE].state = StepState::Ok;
+        steps[IDX_SETUP_PXE].state = StepState::Ok;
+        steps[IDX_SET_BOOT_TARGET].state = StepState::Ok;
+        steps[IDX_REGISTRY_APPROVE].state = StepState::Failed;
+        let row = SagaRow {
+            saga_id: Uuid::new_v4(),
+            kind: saga_kind(MAC),
+            state: SagaState::CompensationPending,
+            steps: steps_to_json(&steps).unwrap(),
+            started_at: Some(now_rfc3339()),
+            finished_at: None,
+        };
+        fx.saga_store.put(&row).await.unwrap();
+
+        let deps = fx.deps(Some(5));
+        let outcomes = resume_unfinished(&deps).await.unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(outcomes[0], SagaOutcome::Compensated { .. }));
+        assert_eq!(
+            fx.log.snapshot(),
+            vec!["clear_host", "clear_host", "remove_host"],
+            "retries then succeeds: {:?}",
+            fx.log.snapshot()
+        );
+    }
+
+    // ── Duplicate / done semantics ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_duplicate_running_saga_refused() {
+        let fx = Fixture::new();
+        let existing = SagaRow {
+            saga_id: Uuid::new_v4(),
+            kind: saga_kind(MAC),
+            state: SagaState::Running,
+            steps: steps_to_json(&initial_steps()).unwrap(),
+            started_at: Some(now_rfc3339()),
+            finished_at: None,
+        };
+        fx.saga_store.put(&existing).await.unwrap();
+
+        let deps = fx.deps(Some(5));
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        match outcome {
+            SagaOutcome::Refused { saga_id, state } => {
+                assert_eq!(saga_id, existing.saga_id, "no second saga is started");
+                assert_eq!(state, SagaState::Running);
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+        assert!(
+            fx.log.snapshot().is_empty(),
+            "no participant call for a refused duplicate: {:?}",
+            fx.log.snapshot()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_done_saga_noop() {
+        let fx = Fixture::new();
+        let existing = SagaRow {
+            saga_id: Uuid::new_v4(),
+            kind: saga_kind(MAC),
+            state: SagaState::Done,
+            steps: steps_to_json(&initial_steps()).unwrap(),
+            started_at: Some(now_rfc3339()),
+            finished_at: Some(now_rfc3339()),
+        };
+        fx.saga_store.put(&existing).await.unwrap();
+
+        let deps = fx.deps(Some(5));
+        let outcome = approve_machine(&deps, MAC).await.unwrap();
+
+        match outcome {
+            SagaOutcome::AlreadyDone { saga_id } => {
+                assert_eq!(saga_id, existing.saga_id);
+            }
+            other => panic!("expected AlreadyDone, got {other:?}"),
+        }
+        assert!(
+            fx.log.snapshot().is_empty(),
+            "a done saga is a no-op success, no participant call: {:?}",
+            fx.log.snapshot()
+        );
+    }
+
+    // ── Backoff schedule (pure) ──────────────────────────────────────────
+
+    #[test]
+    fn test_backoff_schedule_1s_to_5m_cap() {
+        let backoff = Backoff::default();
+        assert_eq!(backoff_delay(0, &backoff), Duration::from_secs(1));
+        assert_eq!(backoff_delay(1, &backoff), Duration::from_secs(2));
+        assert_eq!(backoff_delay(2, &backoff), Duration::from_secs(4));
+        assert_eq!(backoff_delay(9, &backoff), Duration::from_secs(300));
+        assert_eq!(backoff_delay(30, &backoff), Duration::from_secs(300));
+    }
+}


### PR DESCRIPTION
Final 4 wave-4 fillers assembled by the coordinator (re-dispatched post session-limit): IP-01 seeds, IP-03 inventory, CT-05 SAGA, PK-01 CA/EnrollService — all disjoint uaa-control files, plus the router/ConnectInfo wiring.

Two automated security-review findings fixed in-batch:
- **argv flag-smuggling** (inventory certs): identity args flow positionally into `cockroach cert create-node`; added `reject_flaglike` guard (no leading `-`, strict charset) + tests proving zero commands run on a flag-like hostname.
- **renewal identity-spoof** (enroll): same-key renewal now signs from the STORED enrollment row + stored CSR SAN, never the resubmitted claim (worker's own advisor caught it; verified).

Wiring: seeds+inventory merged into machine_plane router; :25000 served via into_make_service_with_connect_info (seed ip-neigh parity). :7444 enroll + :7443 gRPC transport deferred to wave 5.
Gate: 560 tests, clippy --all-targets clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>