### PR TITLE
feat(ops): repeatable server-deploy.sh for uaa-control rollout

### DIFF
--- a/scripts/server-deploy.sh
+++ b/scripts/server-deploy.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# file: scripts/server-deploy.sh
+# version: 1.0.0
+# guid: 9e2f4a71-0b6d-4c8e-9a3f-1d5c7e8b2f60
+# last-edited: 2026-07-11
+#
+# Repeatable build+deploy for the uaa constellation control daemon on the server
+# (172.16.2.30). Lives in the repo so `git pull` always ships the latest version of
+# itself. Intended to be run BY THE OPERATOR on the server, not by an agent — the
+# uaa-control systemd units already say so (crates/uaa-control/systemd/*.service),
+# this script just automates the human steps described there.
+#
+# First run (once, needs your sudo password):
+#   sudo ./scripts/server-deploy.sh --bootstrap
+#     - creates the `uaa` system user/group + /var/lib/uaa
+#     - installs /etc/sudoers.d/uaa-deploy (NOPASSWD for the exact commands below,
+#       so every later run of this script needs no password)
+#     - installs the uaa-control systemd units + daemon-reload
+#
+# Every later run (no sudo password needed):
+#   ./scripts/server-deploy.sh              # git pull, cargo build --release, stage
+#                                            # binaries, restart uaa-control.service
+#                                            # only (does NOT touch :25000 traffic)
+#   ./scripts/server-deploy.sh --status      # show both services + health endpoints
+#   ./scripts/server-deploy.sh --cutover     # stop the Python autoinstall-agent and
+#                                            # hand :25000 to uaa-control.socket
+#                                            # (auto-rolls back if the health check
+#                                            # fails). This is the one irreversible-
+#                                            # feeling step; everything else is safe
+#                                            # to re-run at will.
+#   ./scripts/server-deploy.sh --rollback    # reverse --cutover
+#
+# Why uaa-control.service is safe to restart before --cutover: main.rs binds :25000
+# directly (dev fallback) whenever it is not socket-activated, so before --cutover
+# (uaa-control.socket not enabled) it will fail to bind :25000 (already held by the
+# Python autoinstall-agent.service), systemd's burst limiter parks it in `failed`
+# after a few rapid retries, and the Python service is never touched. Annoying to see
+# in `--status`, harmless. See crates/uaa-control/src/listeners.rs for the bind logic.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT_SERVICE="$REPO_DIR/crates/uaa-control/systemd/uaa-control.service"
+UNIT_SOCKET="$REPO_DIR/crates/uaa-control/systemd/uaa-control.socket"
+SUDOERS_FILE="/etc/sudoers.d/uaa-deploy"
+BIN_UAA_CONTROL="$REPO_DIR/target/release/uaa-control"
+BIN_UAA_AGENT="$REPO_DIR/target/release/ubuntu-autoinstall-agent"
+
+usage() {
+    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+log() { echo "==> $*"; }
+
+require_root() {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "ERROR: --bootstrap must be run with sudo (one-time root setup)." >&2
+        exit 1
+    fi
+}
+
+bootstrap() {
+    require_root
+
+    log "ensuring uaa system group/user"
+    getent group uaa >/dev/null || groupadd --system uaa
+    getent passwd uaa >/dev/null || useradd --system --gid uaa --home-dir /var/lib/uaa \
+        --shell /usr/sbin/nologin --comment "uaa constellation control daemon" uaa
+
+    log "ensuring /var/lib/uaa (registry snapshot + WAL state dir)"
+    install -d -o uaa -g uaa -m 0750 /var/lib/uaa
+
+    log "installing systemd units"
+    cp "$UNIT_SERVICE" /etc/systemd/system/uaa-control.service
+    cp "$UNIT_SOCKET" /etc/systemd/system/uaa-control.socket
+    systemctl daemon-reload
+
+    log "installing $SUDOERS_FILE"
+    local tmp
+    tmp="$(mktemp)"
+    cat >"$tmp" <<EOF
+# file: $SUDOERS_FILE
+# Installed by scripts/server-deploy.sh --bootstrap. Scopes NOPASSWD to the exact
+# commands the repeatable deploy run needs, matching the pattern already used for
+# audiobook-organizer on this host. jdfalk already has unrestricted (ALL:ALL) ALL
+# sudo with a password; this only removes the password prompt for routine re-deploys.
+jdfalk ALL=(root) NOPASSWD: /usr/bin/install -o root -g root -m 0755 $BIN_UAA_CONTROL /usr/local/bin/uaa-control
+jdfalk ALL=(root) NOPASSWD: /usr/bin/install -o root -g root -m 0755 $BIN_UAA_AGENT /usr/local/bin/ubuntu-autoinstall-agent
+jdfalk ALL=(root) NOPASSWD: /usr/bin/cp $UNIT_SERVICE /etc/systemd/system/uaa-control.service
+jdfalk ALL=(root) NOPASSWD: /usr/bin/cp $UNIT_SOCKET /etc/systemd/system/uaa-control.socket
+jdfalk ALL=(root) NOPASSWD: /usr/bin/systemctl daemon-reload
+jdfalk ALL=(root) NOPASSWD: /usr/bin/systemctl start uaa-control.service, /usr/bin/systemctl stop uaa-control.service, /usr/bin/systemctl restart uaa-control.service, /usr/bin/systemctl status uaa-control.service
+jdfalk ALL=(root) NOPASSWD: /usr/bin/systemctl start uaa-control.socket, /usr/bin/systemctl stop uaa-control.socket, /usr/bin/systemctl restart uaa-control.socket, /usr/bin/systemctl status uaa-control.socket
+jdfalk ALL=(root) NOPASSWD: /usr/bin/systemctl enable uaa-control.service, /usr/bin/systemctl disable uaa-control.service, /usr/bin/systemctl enable uaa-control.socket, /usr/bin/systemctl disable uaa-control.socket
+jdfalk ALL=(root) NOPASSWD: /usr/bin/journalctl -u uaa-control.service, /usr/bin/journalctl -fu uaa-control.service
+EOF
+    visudo -cf "$tmp"
+    install -o root -g root -m 0440 "$tmp" "$SUDOERS_FILE"
+    rm -f "$tmp"
+
+    log "bootstrap complete. Run './scripts/server-deploy.sh' (no sudo) from now on."
+}
+
+pull_latest() {
+    if [[ -n "$(git -C "$REPO_DIR" status --porcelain)" ]]; then
+        log "WARNING: $REPO_DIR has local changes, skipping git pull"
+        return
+    fi
+    log "git pull origin main"
+    git -C "$REPO_DIR" fetch origin main
+    git -C "$REPO_DIR" checkout main
+    git -C "$REPO_DIR" pull --ff-only origin main
+}
+
+build() {
+    log "cargo build --release -p uaa-control -p uaa"
+    ( cd "$REPO_DIR" && cargo build --release -p uaa-control -p uaa )
+}
+
+stage() {
+    log "staging binaries + systemd units"
+    sudo install -o root -g root -m 0755 "$BIN_UAA_CONTROL" /usr/local/bin/uaa-control
+    sudo install -o root -g root -m 0755 "$BIN_UAA_AGENT" /usr/local/bin/ubuntu-autoinstall-agent
+    sudo cp "$UNIT_SERVICE" /etc/systemd/system/uaa-control.service
+    sudo cp "$UNIT_SOCKET" /etc/systemd/system/uaa-control.socket
+    sudo systemctl daemon-reload
+}
+
+restart_control() {
+    log "restarting uaa-control.service"
+    sudo systemctl restart uaa-control.service
+    sleep 1
+    sudo systemctl status uaa-control.service --no-pager -l || true
+}
+
+status() {
+    echo "--- autoinstall-agent.service (legacy Python, owns :25000 until --cutover) ---"
+    sudo systemctl status autoinstall-agent.service --no-pager -l || true
+    echo
+    echo "--- uaa-control.service ---"
+    sudo systemctl status uaa-control.service --no-pager -l || true
+    echo
+    echo "--- uaa-control.socket ---"
+    sudo systemctl status uaa-control.socket --no-pager -l || true
+    echo
+    echo "--- health checks ---"
+    for port in 7443 7444 8443; do
+        curl -s -m 2 "http://127.0.0.1:${port}/healthz" && echo || echo "port ${port}: no response"
+    done
+}
+
+cutover() {
+    log "cutover: stopping Python autoinstall-agent.service, handing :25000 to uaa-control.socket"
+    sudo systemctl stop autoinstall-agent.service
+    sudo systemctl enable --now uaa-control.socket
+    sudo systemctl restart uaa-control.service
+    sleep 1
+    if curl -s -m 3 -o /dev/null -w '%{http_code}' http://127.0.0.1:25000/ | grep -qE '^[23]'; then
+        log "cutover OK: :25000 answering via uaa-control"
+    else
+        log "cutover health check FAILED — rolling back to Python"
+        rollback
+        exit 1
+    fi
+}
+
+rollback() {
+    log "rollback: stopping uaa-control.socket, restarting Python autoinstall-agent.service"
+    sudo systemctl disable --now uaa-control.socket 2>/dev/null || sudo systemctl stop uaa-control.socket
+    sudo systemctl start autoinstall-agent.service
+}
+
+case "${1:-}" in
+    --bootstrap) bootstrap ;;
+    --status) status ;;
+    --cutover) cutover ;;
+    --rollback) rollback ;;
+    -h|--help) usage ;;
+    "")
+        pull_latest
+        build
+        stage
+        restart_control
+        ;;
+    *)
+        echo "unknown option: $1" >&2
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `scripts/server-deploy.sh`, meant to live in the server's repo clone and be run directly by the operator on 172.16.2.30.
- `--bootstrap` (one-time, sudo): creates the `uaa` system user/group, `/var/lib/uaa`, installs the `uaa-control` systemd units, and drops a scoped `/etc/sudoers.d/uaa-deploy` NOPASSWD file matching the existing audiobook-organizer pattern on that host.
- Default (no args, no sudo password needed after bootstrap): `git pull` → `cargo build --release -p uaa-control -p uaa` → stage binaries/units → `systemctl restart uaa-control.service`. Never touches the live `:25000` Python `autoinstall-agent.service`.
- `--status` / `--cutover` / `--rollback`: the actual traffic swap to uaa-control's socket-activated `:25000` is an explicit, health-checked, auto-rolling-back step — not something a routine re-deploy does by accident.

## Test plan
- [x] `bash -n scripts/server-deploy.sh` (syntax check)
- [ ] Run `sudo ./scripts/server-deploy.sh --bootstrap` on 172.16.2.30 once
- [ ] Run `./scripts/server-deploy.sh` and confirm `uaa-control.service` builds/stages/restarts without a password prompt
- [ ] `--status` shows Python still owns `:25000`
- [ ] `--cutover` / `--rollback` round-trip cleanly when the operator is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8fqXPVTDHZS6DMZEFimEJ