### PR TITLE
fix(control): install a real tracing subscriber in uaa-control

### DIFF
--- a/crates/uaa-control/Cargo.toml
+++ b/crates/uaa-control/Cargo.toml
@@ -1,7 +1,7 @@
 # file: crates/uaa-control/Cargo.toml
-# version: 1.1.1
+# version: 1.2.0
 # guid: 1e1a4386-a459-4a97-8baf-c942283b3107
-# last-edited: 2026-07-10
+# last-edited: 2026-07-11
 
 [package]
 name = "uaa-control"
@@ -44,6 +44,7 @@ sha2 = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
 # Wave-4 fillers: OAuth/RBAC (CT-03), audit chain (CT-04), parity endpoints (IP-01/02)
 reqwest = { workspace = true }

--- a/crates/uaa-control/src/main.rs
+++ b/crates/uaa-control/src/main.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/main.rs
-// version: 1.0.0
+// version: 1.1.0
 // guid: 608d78f5-ac4c-43a5-b29f-e9008a300858
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 //! Thin entrypoint for the `uaa-control` daemon. All logic lives in `uaa_control`
 //! (the library) so `cargo test --lib --offline` exercises it. `serve` is the default
@@ -47,9 +47,21 @@ fn not_yet_implemented(cmd: &str, owner: &str) -> ! {
     std::process::exit(1);
 }
 
-/// Minimal tracing init without pulling extra deps into the workspace table.
+/// Install a real tracing subscriber writing to stdout (captured by the
+/// systemd journal under `journalctl -u uaa-control`). Without this call,
+/// every `tracing::info!`/`warn!`/etc. in the whole binary is a silent no-op
+/// — including the machine-plane AUTOINSTALL/UAA-CONFIG DENIED/served logs
+/// this daemon's only debug signal depends on (surfaced 2026-07-11: a stalled
+/// hardware autoinstall attempt left zero log evidence, indistinguishable
+/// from "request never arrived").
+///
+/// Level defaults to `info` (so those logs show up out of the box) and is
+/// overridable via `RUST_LOG` (e.g. `RUST_LOG=uaa_control=debug`).
 fn tracing_subscriber_init() {
-    // uaa-core already depends on tracing-subscriber; uaa-control keeps the binary
-    // thin and lets tracing default to a no-op subscriber if none is installed. A
-    // richer subscriber is a runtime/deploy concern (Bucket-3), not scaffold code.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 }


### PR DESCRIPTION
## Summary
- `tracing_subscriber_init()` in `crates/uaa-control/src/main.rs` was an empty
  function body — no subscriber was ever installed, so every `tracing::info!`
  call in the binary (including the machine-plane AUTOINSTALL/UAA-CONFIG
  served/DENIED logs) was a silent no-op.
- `journalctl -u uaa-control` showed nothing at all for live requests,
  making it impossible to tell "request never arrived" from "request arrived
  and was silently denied."
- Wire up `tracing_subscriber::fmt()` to stdout (captured by the systemd
  journal), defaulting to `info`, overridable via `RUST_LOG`.

Found live while debugging a stalled hardware autoinstall attempt — the
service's own logs gave zero signal either way.

## Test plan
- [x] `cargo build -p uaa-control` succeeds
- [ ] After deploy, `journalctl -u uaa-control -f` shows AUTOINSTALL/UAA-CONFIG
      log lines for real requests