### PR TITLE
chore(fmt): rustfmt machine_plane + db submodules

### DIFF
--- a/crates/uaa-control/src/db/registry.rs
+++ b/crates/uaa-control/src/db/registry.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/db/registry.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: 02d40065-96da-4469-b679-b8bfd4f0b8b3
-// last-edited: 2026-07-10
+// last-edited: 2026-07-12
 
 //! Registry CRUD against CockroachDB (the `RegistryStore` trait + tokio-postgres impl).
 //!
@@ -340,7 +340,13 @@ impl RegistryStore for PgRegistryStore {
         self.client
             .execute(
                 SQL_UPSERT_TANG_SERVER,
-                &[&row.hostname, &row.ip, &row.tang_url, &adv_keys, &row.last_seen],
+                &[
+                    &row.hostname,
+                    &row.ip,
+                    &row.tang_url,
+                    &adv_keys,
+                    &row.last_seen,
+                ],
             )
             .await?;
         Ok(())
@@ -352,7 +358,13 @@ impl RegistryStore for PgRegistryStore {
             .client
             .execute(
                 SQL_INSERT_TANG_IF_ABSENT,
-                &[&row.hostname, &row.ip, &row.tang_url, &adv_keys, &row.last_seen],
+                &[
+                    &row.hostname,
+                    &row.ip,
+                    &row.tang_url,
+                    &adv_keys,
+                    &row.last_seen,
+                ],
             )
             .await?;
         Ok(n == 1)
@@ -378,7 +390,10 @@ impl RegistryStore for PgRegistryStore {
     }
 
     async fn list_luks_credentials(&self, mac: &str) -> Result<Vec<LuksCredentialRow>> {
-        let rows = self.client.query(SQL_LIST_LUKS_CREDENTIALS, &[&mac]).await?;
+        let rows = self
+            .client
+            .query(SQL_LIST_LUKS_CREDENTIALS, &[&mac])
+            .await?;
         rows.iter().map(row_to_luks).collect()
     }
 

--- a/crates/uaa-control/src/db/store.rs
+++ b/crates/uaa-control/src/db/store.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/db/store.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: a471e102-2da9-4bf8-8531-1de7595fd24d
-// last-edited: 2026-07-10
+// last-edited: 2026-07-12
 
 //! Degraded-mode layer (spec Decision 4).
 //!
@@ -538,7 +538,10 @@ mod tests {
         assert_eq!(apply.applied, vec![e1.event_id, e3.event_id]);
 
         let q = fs::read_to_string(&paths.quarantine).unwrap();
-        assert!(q.contains("this is not valid json"), "corrupt line preserved");
+        assert!(
+            q.contains("this is not valid json"),
+            "corrupt line preserved"
+        );
     }
 
     #[tokio::test]

--- a/crates/uaa-control/src/machine_plane/inventory.rs
+++ b/crates/uaa-control/src/machine_plane/inventory.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/machine_plane/inventory.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: 76633c84-b337-47da-ab77-11cbf0f4b3b5
-// last-edited: 2026-07-10
+// last-edited: 2026-07-12
 
 //! Machine-plane operator/inventory endpoints (`:25000` parity, spec Decision 12).
 //!
@@ -534,7 +534,9 @@ fn default_state() -> AppState {
         ipxe_dir: Arc::new(PathBuf::from(IPXE_BOOT_DIR)),
         ca_crt: Arc::new(PathBuf::from(COCKROACH_CA_CRT)),
         ca_key: Arc::new(PathBuf::from(COCKROACH_CA_KEY)),
-        executor_factory: Arc::new(|| Box::new(LocalClient::new()) as Box<dyn CommandExecutor + Send>),
+        executor_factory: Arc::new(|| {
+            Box::new(LocalClient::new()) as Box<dyn CommandExecutor + Send>
+        }),
     }
 }
 
@@ -631,8 +633,19 @@ async fn handle_certs(
     }
 
     let mut executor = (state.executor_factory)();
-    match generate_certs(executor.as_mut(), &state.ca_crt, &state.ca_key, &hostname, &ip).await {
-        Err(err) => json_response(StatusCode::INTERNAL_SERVER_ERROR, json!({"ok": false, "error": err})),
+    match generate_certs(
+        executor.as_mut(),
+        &state.ca_crt,
+        &state.ca_key,
+        &hostname,
+        &ip,
+    )
+    .await
+    {
+        Err(err) => json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({"ok": false, "error": err}),
+        ),
         Ok(certs) => {
             tracing::info!(%hostname, %ip, "CERTS issued");
             json_response(StatusCode::OK, json!({"ok": true, "certs": certs}))
@@ -665,19 +678,36 @@ async fn handle_flip(
     }
     let (ok, msg) = flip_ipxe(state.registry.as_ref(), &state.ipxe_dir, &hostname, &target).await;
     tracing::info!(%hostname, %target, %ok, %msg, "FLIP");
-    let code = if ok { StatusCode::OK } else { StatusCode::NOT_FOUND };
+    let code = if ok {
+        StatusCode::OK
+    } else {
+        StatusCode::NOT_FOUND
+    };
     json_response(code, json!({"ok": ok, "message": msg}))
 }
 
 // ── /api/approve/<mac> (Python `:332-344`) ───────────────────────────────────
 
-async fn handle_approve(State(state): State<AppState>, AxumPath(mac_raw): AxumPath<String>) -> Response {
+async fn handle_approve(
+    State(state): State<AppState>,
+    AxumPath(mac_raw): AxumPath<String>,
+) -> Response {
     let mac = normalize_mac(&mac_raw);
     if state.registry.get_machine(&mac).await.is_none() {
-        return json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "MAC not registered"}));
+        return json_response(
+            StatusCode::NOT_FOUND,
+            json!({"ok": false, "error": "MAC not registered"}),
+        );
     }
-    match state.registry.approve_machine(&mac, now_epoch_string()).await {
-        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "MAC not registered"})),
+    match state
+        .registry
+        .approve_machine(&mac, now_epoch_string())
+        .await
+    {
+        None => json_response(
+            StatusCode::NOT_FOUND,
+            json!({"ok": false, "error": "MAC not registered"}),
+        ),
         Some(row) => {
             tracing::info!(%mac, hostname = %row.hostname, "APPROVED");
             json_response(
@@ -690,10 +720,16 @@ async fn handle_approve(State(state): State<AppState>, AxumPath(mac_raw): AxumPa
 
 // ── /api/deregister/<mac> (Python `:347-359`) ────────────────────────────────
 
-async fn handle_deregister(State(state): State<AppState>, AxumPath(mac_raw): AxumPath<String>) -> Response {
+async fn handle_deregister(
+    State(state): State<AppState>,
+    AxumPath(mac_raw): AxumPath<String>,
+) -> Response {
     let mac = normalize_mac(&mac_raw);
     match state.registry.delete_machine(&mac).await {
-        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "MAC not registered"})),
+        None => json_response(
+            StatusCode::NOT_FOUND,
+            json!({"ok": false, "error": "MAC not registered"}),
+        ),
         Some(row) => {
             tracing::info!(%mac, hostname = %row.hostname, "DEREGISTERED");
             json_response(
@@ -748,10 +784,16 @@ async fn handle_yubikeys_ssh_keys(State(state): State<AppState>) -> Response {
 
 // ── /api/yubikeys/approve/<fingerprint> (Python `:433-446`) ──────────────────
 
-async fn handle_yubikey_approve(State(state): State<AppState>, AxumPath(fp_raw): AxumPath<String>) -> Response {
+async fn handle_yubikey_approve(
+    State(state): State<AppState>,
+    AxumPath(fp_raw): AxumPath<String>,
+) -> Response {
     let fp = fp_raw.to_uppercase();
     match state.registry.approve_yubikey(&fp, now_epoch_i64()).await {
-        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "Fingerprint not registered"})),
+        None => json_response(
+            StatusCode::NOT_FOUND,
+            json!({"ok": false, "error": "Fingerprint not registered"}),
+        ),
         Some(entry) => {
             tracing::info!(fingerprint = %fp, comment = ?entry.comment, "YUBIKEY APPROVED");
             json_response(
@@ -770,10 +812,16 @@ async fn handle_yubikey_approve(State(state): State<AppState>, AxumPath(fp_raw):
 /// `{"ok":false,"error":"No GPG key..."}` this handler uses for a
 /// well-formed-but-unknown fingerprint.
 fn is_valid_fp_format(fp: &str) -> bool {
-    !fp.is_empty() && fp.chars().all(|c| c.is_ascii_digit() || ('A'..='F').contains(&c))
+    !fp.is_empty()
+        && fp
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('A'..='F').contains(&c))
 }
 
-async fn handle_yubikey_pubkey(State(state): State<AppState>, AxumPath(fp): AxumPath<String>) -> Response {
+async fn handle_yubikey_pubkey(
+    State(state): State<AppState>,
+    AxumPath(fp): AxumPath<String>,
+) -> Response {
     if !is_valid_fp_format(&fp) {
         return handle_not_found().await;
     }
@@ -788,7 +836,10 @@ async fn handle_yubikey_pubkey(State(state): State<AppState>, AxumPath(fp): Axum
         }
     };
     if entry.status != "approved" {
-        return json_response(StatusCode::FORBIDDEN, json!({"ok": false, "error": "YubiKey not approved"}));
+        return json_response(
+            StatusCode::FORBIDDEN,
+            json!({"ok": false, "error": "YubiKey not approved"}),
+        );
     }
     let body = entry.gpg_pubkey.unwrap_or_default();
     Response::builder()
@@ -800,13 +851,22 @@ async fn handle_yubikey_pubkey(State(state): State<AppState>, AxumPath(fp): Axum
 
 // ── /api/yubikeys/revoke/<fingerprint> (Python `:467-480`) ───────────────────
 
-async fn handle_yubikey_revoke(State(state): State<AppState>, AxumPath(fp_raw): AxumPath<String>) -> Response {
+async fn handle_yubikey_revoke(
+    State(state): State<AppState>,
+    AxumPath(fp_raw): AxumPath<String>,
+) -> Response {
     let fp = fp_raw.to_uppercase();
     match state.registry.revoke_yubikey(&fp, now_epoch_i64()).await {
-        None => json_response(StatusCode::NOT_FOUND, json!({"ok": false, "error": "Fingerprint not registered"})),
+        None => json_response(
+            StatusCode::NOT_FOUND,
+            json!({"ok": false, "error": "Fingerprint not registered"}),
+        ),
         Some(entry) => {
             tracing::info!(fingerprint = %fp, comment = ?entry.comment, "YUBIKEY REVOKED");
-            json_response(StatusCode::OK, json!({"ok": true, "message": format!("Revoked {fp}")}))
+            json_response(
+                StatusCode::OK,
+                json!({"ok": true, "message": format!("Revoked {fp}")}),
+            )
         }
     }
 }
@@ -817,7 +877,10 @@ async fn handle_tang_servers(State(state): State<AppState>) -> Response {
     let tang = state.registry.list_tang().await;
     let mut map = serde_json::Map::new();
     for row in tang {
-        map.insert(row.hostname.clone(), serde_json::to_value(&row).unwrap_or(Value::Null));
+        map.insert(
+            row.hostname.clone(),
+            serde_json::to_value(&row).unwrap_or(Value::Null),
+        );
     }
     json_response(StatusCode::OK, Value::Object(map))
 }
@@ -846,17 +909,32 @@ async fn handle_yubikey_register(State(state): State<AppState>, body: Bytes) -> 
         .to_uppercase()
         .replace(' ', "");
     if fp.is_empty() {
-        return json_response(StatusCode::BAD_REQUEST, json!({"ok": false, "error": "fingerprint required"}));
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            json!({"ok": false, "error": "fingerprint required"}),
+        );
     }
 
     let entry = YubikeyEntry {
         fingerprint: fp.clone(),
-        gpg_pubkey: data.get("gpg_pubkey").and_then(Value::as_str).map(str::to_string),
-        ssh_pubkey: data.get("ssh_pubkey").and_then(Value::as_str).map(str::to_string),
-        comment: data.get("comment").and_then(Value::as_str).map(str::to_string),
-        serial: data.get("serial").and_then(Value::as_str).map(str::to_string),
-        status: String::new(),  // overwritten by upsert_yubikey_register
-        registered_at: None,    // overwritten by upsert_yubikey_register
+        gpg_pubkey: data
+            .get("gpg_pubkey")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        ssh_pubkey: data
+            .get("ssh_pubkey")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        comment: data
+            .get("comment")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        serial: data
+            .get("serial")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        status: String::new(), // overwritten by upsert_yubikey_register
+        registered_at: None,   // overwritten by upsert_yubikey_register
         approved_at: None,
         revoked_at: None,
     };
@@ -882,15 +960,27 @@ async fn handle_tang_checkin(State(state): State<AppState>, body: Bytes) -> Resp
         Err(r) => return r,
     };
 
-    let hostname = data.get("hostname").and_then(Value::as_str).unwrap_or("").to_string();
-    let ip = data.get("ip").and_then(Value::as_str).unwrap_or("").to_string();
+    let hostname = data
+        .get("hostname")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let ip = data
+        .get("ip")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
     let tang_url = data
         .get("tang_url")
         .and_then(Value::as_str)
         .map(str::to_string)
         .unwrap_or_else(|| format!("http://{ip}"));
     let adv_keys = data.get("adv_keys").cloned();
-    let adv_keys_count = adv_keys.as_ref().and_then(Value::as_array).map(Vec::len).unwrap_or(0);
+    let adv_keys_count = adv_keys
+        .as_ref()
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
 
     let row = TangServerRow {
         hostname: hostname.clone(),
@@ -1031,7 +1121,11 @@ mod tests {
         }
     }
 
-    fn test_state(registry: Arc<dyn Registry>, ipxe_dir: PathBuf, recorded: Arc<Mutex<Vec<String>>>) -> AppState {
+    fn test_state(
+        registry: Arc<dyn Registry>,
+        ipxe_dir: PathBuf,
+        recorded: Arc<Mutex<Vec<String>>>,
+    ) -> AppState {
         AppState {
             registry,
             ipxe_dir: Arc::new(ipxe_dir),
@@ -1089,7 +1183,9 @@ mod tests {
     }
 
     async fn body_json(resp: Response) -> Value {
-        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         serde_json::from_slice(&bytes).unwrap()
     }
 
@@ -1134,13 +1230,19 @@ mod tests {
         let resp = handle_certs(
             State(state),
             AxumPath("ghost-host".to_string()),
-            Query(CertsQuery { ip: None, mac: None }),
+            Query(CertsQuery {
+                ip: None,
+                mac: None,
+            }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         let v = body_json(resp).await;
         assert_eq!(v["ok"], false);
-        assert_eq!(v["error"], "Not registered. Run register-len-server.sh first.");
+        assert_eq!(
+            v["error"],
+            "Not registered. Run register-len-server.sh first."
+        );
     }
 
     #[tokio::test]
@@ -1157,7 +1259,10 @@ mod tests {
         let resp = handle_certs(
             State(state),
             AxumPath("pending-host".to_string()),
-            Query(CertsQuery { ip: None, mac: None }),
+            Query(CertsQuery {
+                ip: None,
+                mac: None,
+            }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -1184,7 +1289,10 @@ mod tests {
         let resp = handle_certs(
             State(state),
             AxumPath("ok-host".to_string()),
-            Query(CertsQuery { ip: Some("10.0.0.9".to_string()), mac: None }),
+            Query(CertsQuery {
+                ip: Some("10.0.0.9".to_string()),
+                mac: None,
+            }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1207,7 +1315,11 @@ mod tests {
     #[tokio::test]
     async fn test_flip_install_requires_approved() {
         let dir = tempdir().unwrap();
-        write_ipxe(dir.path(), "mac-aabbccddeeff.ipxe", "#!ipxe\nset menu-default pxe-install\nboot\n");
+        write_ipxe(
+            dir.path(),
+            "mac-aabbccddeeff.ipxe",
+            "#!ipxe\nset menu-default pxe-install\nboot\n",
+        );
         let registry = Arc::new(MockRegistry::default());
         registry.machines.lock().unwrap().insert(
             "aa:bb:cc:dd:ee:ff".to_string(),
@@ -1219,7 +1331,9 @@ mod tests {
         let resp = handle_flip(
             State(state.clone()),
             AxumPath("flip-host".to_string()),
-            Query(FlipQuery { target: Some("custom-autoinstall".to_string()) }),
+            Query(FlipQuery {
+                target: Some("custom-autoinstall".to_string()),
+            }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -1234,7 +1348,9 @@ mod tests {
         let resp2 = handle_flip(
             State(state),
             AxumPath("flip-host".to_string()),
-            Query(FlipQuery { target: Some("custom-autoinstall".to_string()) }),
+            Query(FlipQuery {
+                target: Some("custom-autoinstall".to_string()),
+            }),
         )
         .await;
         assert_eq!(resp2.status(), StatusCode::OK);
@@ -1247,7 +1363,11 @@ mod tests {
     #[tokio::test]
     async fn test_flip_local_disk_no_registration_needed() {
         let dir = tempdir().unwrap();
-        write_ipxe(dir.path(), "some-file.ipxe", "#!ipxe\nset hostname unreg-host\nset menu-default pxe-install\nboot\n");
+        write_ipxe(
+            dir.path(),
+            "some-file.ipxe",
+            "#!ipxe\nset hostname unreg-host\nset menu-default pxe-install\nboot\n",
+        );
         let registry = Arc::new(MockRegistry::default());
         let recorded = Arc::new(Mutex::new(Vec::new()));
         let state = test_state(registry, dir.path().to_path_buf(), recorded);
@@ -1401,7 +1521,12 @@ mod tests {
 
     // ── yubikeys ──────────────────────────────────────────────────────
 
-    fn sample_yubikey(fp: &str, status: &str, gpg: Option<&str>, ssh: Option<&str>) -> YubikeyEntry {
+    fn sample_yubikey(
+        fp: &str,
+        status: &str,
+        gpg: Option<&str>,
+        ssh: Option<&str>,
+    ) -> YubikeyEntry {
         YubikeyEntry {
             fingerprint: fp.to_string(),
             gpg_pubkey: gpg.map(str::to_string),
@@ -1421,7 +1546,12 @@ mod tests {
         let registry = Arc::new(MockRegistry::default());
         registry.yubikeys.lock().unwrap().insert(
             "DEADBEEF".to_string(),
-            sample_yubikey("DEADBEEF", "approved", Some("-----BEGIN PGP PUBLIC KEY-----\nabc\n"), Some("ssh-ed25519 AAAA")),
+            sample_yubikey(
+                "DEADBEEF",
+                "approved",
+                Some("-----BEGIN PGP PUBLIC KEY-----\nabc\n"),
+                Some("ssh-ed25519 AAAA"),
+            ),
         );
         let recorded = Arc::new(Mutex::new(Vec::new()));
         let state = test_state(registry, dir.path().to_path_buf(), recorded);
@@ -1430,22 +1560,31 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         let entry = &v["DEADBEEF"];
-        assert!(entry.get("gpg_pubkey").is_none(), "gpg_pubkey must be stripped from listing");
+        assert!(
+            entry.get("gpg_pubkey").is_none(),
+            "gpg_pubkey must be stripped from listing"
+        );
         assert_eq!(entry["status"], "approved");
 
         // /pubkey still returns the armored block for an approved fp.
-        let resp2 = handle_yubikey_pubkey(State(state.clone()), AxumPath("DEADBEEF".to_string())).await;
+        let resp2 =
+            handle_yubikey_pubkey(State(state.clone()), AxumPath("DEADBEEF".to_string())).await;
         assert_eq!(resp2.status(), StatusCode::OK);
         assert_eq!(
             resp2.headers().get("content-type").unwrap(),
             "application/pgp-keys"
         );
-        let bytes = axum::body::to_bytes(resp2.into_body(), usize::MAX).await.unwrap();
+        let bytes = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+            .await
+            .unwrap();
         assert!(String::from_utf8_lossy(&bytes).contains("BEGIN PGP PUBLIC KEY"));
 
         // Unapproved fp -> 403 on /pubkey.
         let state2 = state.clone();
-        state2.registry.upsert_yubikey_register(sample_yubikey("ABCDEF01", "pending", Some("armored"), None)).await;
+        state2
+            .registry
+            .upsert_yubikey_register(sample_yubikey("ABCDEF01", "pending", Some("armored"), None))
+            .await;
         let resp3 = handle_yubikey_pubkey(State(state2), AxumPath("ABCDEF01".to_string())).await;
         assert_eq!(resp3.status(), StatusCode::FORBIDDEN);
         let v3 = body_json(resp3).await;
@@ -1492,9 +1631,18 @@ mod tests {
         let registry = Arc::new(MockRegistry::default());
         {
             let mut yk = registry.yubikeys.lock().unwrap();
-            yk.insert("A".to_string(), sample_yubikey("A", "approved", None, Some("ssh-key-a")));
-            yk.insert("B".to_string(), sample_yubikey("B", "pending", None, Some("ssh-key-b")));
-            yk.insert("C".to_string(), sample_yubikey("C", "approved", None, Some("")));
+            yk.insert(
+                "A".to_string(),
+                sample_yubikey("A", "approved", None, Some("ssh-key-a")),
+            );
+            yk.insert(
+                "B".to_string(),
+                sample_yubikey("B", "pending", None, Some("ssh-key-b")),
+            );
+            yk.insert(
+                "C".to_string(),
+                sample_yubikey("C", "approved", None, Some("")),
+            );
         }
         let recorded = Arc::new(Mutex::new(Vec::new()));
         let state = test_state(registry, dir.path().to_path_buf(), recorded);
@@ -1554,8 +1702,10 @@ mod tests {
         let state = test_state(registry, dir.path().to_path_buf(), recorded);
 
         let body = Bytes::from(
-            serde_json::to_vec(&json!({"hostname": "tang1", "ip": "10.0.0.5", "adv_keys": [1, 2, 3]}))
-                .unwrap(),
+            serde_json::to_vec(
+                &json!({"hostname": "tang1", "ip": "10.0.0.5", "adv_keys": [1, 2, 3]}),
+            )
+            .unwrap(),
         );
         let resp = handle_tang_checkin(State(state.clone()), body).await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1577,7 +1727,8 @@ mod tests {
         let recorded = Arc::new(Mutex::new(Vec::new()));
         let state = test_state(registry, dir.path().to_path_buf(), recorded);
 
-        let resp = handle_yubikey_register(State(state.clone()), Bytes::from_static(b"not json")).await;
+        let resp =
+            handle_yubikey_register(State(state.clone()), Bytes::from_static(b"not json")).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         let resp2 = handle_tang_checkin(State(state), Bytes::from_static(b"{bad")).await;
@@ -1596,11 +1747,23 @@ mod tests {
     fn test_reject_flaglike_blocks_argv_injection() {
         // Flag-like identities must be refused before any cert command is built.
         for evil in ["--certs-dir=/evil", "-x", "a b", "a;b", "$(id)", "a/b"] {
-            assert!(reject_flaglike("hostname", evil).is_err(), "allowed: {evil:?}");
+            assert!(
+                reject_flaglike("hostname", evil).is_err(),
+                "allowed: {evil:?}"
+            );
         }
         // Anti-over-suppression: legitimate host/IP tokens still pass.
-        for good in ["len-serv-001", "len-serv-001.jf.local", "172.16.2.30", "fe80::1", "host_1"] {
-            assert!(reject_flaglike("hostname", good).is_ok(), "rejected: {good:?}");
+        for good in [
+            "len-serv-001",
+            "len-serv-001.jf.local",
+            "172.16.2.30",
+            "fe80::1",
+            "host_1",
+        ] {
+            assert!(
+                reject_flaglike("hostname", good).is_ok(),
+                "rejected: {good:?}"
+            );
         }
     }
 
@@ -1608,7 +1771,9 @@ mod tests {
     async fn test_generate_certs_rejects_flaglike_before_exec() {
         // A flag-like hostname records ZERO executor commands (fail-closed before shell-out).
         let recorded = Arc::new(Mutex::new(Vec::new()));
-        let mut exec = RecordingExecutor { recorded: recorded.clone() };
+        let mut exec = RecordingExecutor {
+            recorded: recorded.clone(),
+        };
         let ca = Path::new("/tmp/ca.crt");
         let err = generate_certs(&mut exec, ca, ca, "--certs-dir=/evil", "172.16.2.30")
             .await

--- a/crates/uaa-control/src/machine_plane/lifecycle.rs
+++ b/crates/uaa-control/src/machine_plane/lifecycle.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/machine_plane/lifecycle.rs
-// version: 1.1.2
+// version: 1.1.3
 // guid: f1273168-f053-480d-8baf-aa653555cb85
-// last-edited: 2026-07-10
+// last-edited: 2026-07-12
 
 //! Machine-plane checkin + install-event ingest (WAL append when degraded).
 //!
@@ -84,8 +84,10 @@ pub fn webhook_should_flip(data: &Value) -> bool {
 /// `re.sub(r"set menu-default \S+", f"set menu-default {target}", content)`.
 pub fn flip_ipxe_content(content: &str, target: &str) -> String {
     let re = regex::Regex::new(r"set menu-default \S+").expect("static regex is valid");
-    re.replace_all(content, |_: &regex::Captures| format!("set menu-default {target}"))
-        .into_owned()
+    re.replace_all(content, |_: &regex::Captures| {
+        format!("set menu-default {target}")
+    })
+    .into_owned()
 }
 
 // ── Registry seam (mockable; no direct DB/process access) ───────────────────
@@ -111,7 +113,13 @@ pub trait Registry: Send + Sync {
     /// schema). Mints a fresh `event_id` UUID AT INGEST — the WAL-replay dedup key
     /// (Decision 4a) — and returns it. Also updates the machine's `installed_at` +
     /// `last_install_status`.
-    async fn record_install_event(&self, mac: &str, name: &str, status: &str, finished_at: &str) -> uuid::Uuid;
+    async fn record_install_event(
+        &self,
+        mac: &str,
+        name: &str,
+        status: &str,
+        finished_at: &str,
+    ) -> uuid::Uuid;
 }
 
 /// Real [`Registry`]: backed by CT-01's local snapshot (`SnapshotDoc.machines`)
@@ -165,7 +173,13 @@ impl Registry for FileRegistry {
         }
     }
 
-    async fn record_install_event(&self, mac: &str, name: &str, status: &str, finished_at: &str) -> uuid::Uuid {
+    async fn record_install_event(
+        &self,
+        mac: &str,
+        name: &str,
+        status: &str,
+        finished_at: &str,
+    ) -> uuid::Uuid {
         let payload = json!({
             "mac": mac,
             "name": name,
@@ -310,7 +324,9 @@ async fn handle_register(State(state): State<AppState>, body: Bytes) -> Response
     let last_seen = existing.as_ref().and_then(|m| m.last_seen.clone());
     let last_ip = existing.as_ref().and_then(|m| m.last_ip.clone());
     let installed_at = existing.as_ref().and_then(|m| m.installed_at.clone());
-    let last_install_status = existing.as_ref().and_then(|m| m.last_install_status.clone());
+    let last_install_status = existing
+        .as_ref()
+        .and_then(|m| m.last_install_status.clone());
 
     let row = MachineRow {
         mac: mac.clone(),
@@ -533,7 +549,11 @@ fn save_webhook_file(files_dir: &std::path::Path, hostname: &str, f: &Value) {
 /// hostname, then rewrite `set menu-default \S+` to the given target. A missing
 /// file (or any IO error) returns `(false, "No iPXE file found for {hostname}")`
 /// / a swallowed error message — never propagated.
-async fn flip_ipxe(registry: &dyn Registry, ipxe_dir: &std::path::Path, hostname: &str) -> (bool, String) {
+async fn flip_ipxe(
+    registry: &dyn Registry,
+    ipxe_dir: &std::path::Path,
+    hostname: &str,
+) -> (bool, String) {
     let path = match resolve_ipxe_path(registry, ipxe_dir, hostname).await {
         Some(p) if p.exists() => p,
         _ => return (false, format!("No iPXE file found for {hostname}")),
@@ -670,13 +690,16 @@ mod tests {
             finished_at: &str,
         ) -> uuid::Uuid {
             let event_id = uuid::Uuid::new_v4();
-            self.install_events.lock().unwrap().push(RecordedInstallEvent {
-                event_id,
-                mac: mac.to_string(),
-                name: name.to_string(),
-                status: status.to_string(),
-                finished_at: finished_at.to_string(),
-            });
+            self.install_events
+                .lock()
+                .unwrap()
+                .push(RecordedInstallEvent {
+                    event_id,
+                    mac: mac.to_string(),
+                    name: name.to_string(),
+                    status: status.to_string(),
+                    finished_at: finished_at.to_string(),
+                });
             // Mirror FileRegistry's side effect so tests can assert on it too.
             if let Some(row) = self.machines.lock().unwrap().get_mut(mac) {
                 row.installed_at = Some(finished_at.to_string());
@@ -798,10 +821,18 @@ mod tests {
         assert_eq!(v["status"], "approved");
 
         let updated = registry.get_machine("aa:bb:cc:dd:ee:ff").await.unwrap();
-        assert_eq!(updated.status, MachineStatus::Approved, "approval preserved");
+        assert_eq!(
+            updated.status,
+            MachineStatus::Approved,
+            "approval preserved"
+        );
         assert_eq!(updated.tpm_ek.as_deref(), Some("ek-123"), "EK preserved");
         assert_eq!(updated.hostname, "new-host", "hostname overwritten");
-        assert_eq!(updated.registered_at.as_deref(), Some("1000"), "registered_at preserved");
+        assert_eq!(
+            updated.registered_at.as_deref(),
+            Some("1000"),
+            "registered_at preserved"
+        );
     }
 
     #[tokio::test]
@@ -829,8 +860,10 @@ mod tests {
 
         // First checkin binds the EK.
         let body1 = Bytes::from(
-            serde_json::to_vec(&json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-1", "ip": "10.0.0.5"}))
-                .unwrap(),
+            serde_json::to_vec(
+                &json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-1", "ip": "10.0.0.5"}),
+            )
+            .unwrap(),
         );
         let resp1 = handle_checkin(State(state.clone()), body1).await;
         assert_eq!(resp1.status(), StatusCode::OK);
@@ -845,8 +878,10 @@ mod tests {
 
         // Second checkin with a DIFFERENT EK -> 403, last_seen untouched.
         let body2 = Bytes::from(
-            serde_json::to_vec(&json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-2", "ip": "10.0.0.6"}))
-                .unwrap(),
+            serde_json::to_vec(
+                &json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-2", "ip": "10.0.0.6"}),
+            )
+            .unwrap(),
         );
         let resp2 = handle_checkin(State(state.clone()), body2).await;
         assert_eq!(resp2.status(), StatusCode::FORBIDDEN);
@@ -878,8 +913,10 @@ mod tests {
         let state = test_state_with(registry.clone(), dir.path().to_path_buf());
 
         let body = Bytes::from(
-            serde_json::to_vec(&json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-1", "ip": "10.0.0.9"}))
-                .unwrap(),
+            serde_json::to_vec(
+                &json!({"mac": "aa:bb:cc:dd:ee:ff", "tpm_ek": "ek-1", "ip": "10.0.0.9"}),
+            )
+            .unwrap(),
         );
         let resp = handle_checkin(State(state), body).await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -894,7 +931,11 @@ mod tests {
             "legitimate checkin must update last_seen"
         );
         assert_eq!(updated.last_ip.as_deref(), Some("10.0.0.9"));
-        assert_eq!(updated.tpm_ek.as_deref(), Some("ek-1"), "EK unchanged on match");
+        assert_eq!(
+            updated.tpm_ek.as_deref(),
+            Some("ek-1"),
+            "EK unchanged on match"
+        );
     }
 
     // ── /api/webhook ─────────────────────────────────────────────────────
@@ -916,7 +957,11 @@ mod tests {
             .unwrap(),
         );
         let resp = handle_webhook(State(state), body).await;
-        assert_eq!(resp.status(), StatusCode::OK, "flip failure must be swallowed");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "flip failure must be swallowed"
+        );
         let v = body_json(resp).await;
         assert_eq!(v["ok"], true);
 
@@ -959,7 +1004,11 @@ mod tests {
 
         let events = registry.install_events.lock().unwrap();
         assert_eq!(events.len(), 1, "exactly one install_history record");
-        assert_ne!(events[0].event_id, uuid::Uuid::nil(), "event_id must be a minted UUID");
+        assert_ne!(
+            events[0].event_id,
+            uuid::Uuid::nil(),
+            "event_id must be a minted UUID"
+        );
         assert_eq!(events[0].mac, "aa:bb:cc:dd:ee:ff");
     }
 


### PR DESCRIPTION
## Summary
- Pure rustfmt pass over `lifecycle.rs`, `inventory.rs`, `db/registry.rs`, `db/store.rs` — no logic changes.
- Split out ahead of #machine-plane-dashboard so that PR's diff isn't polluted by incidental reformatting rustfmt pulls in when it walks the module tree from `mod.rs`.

## Test plan
- [x] `cargo build --offline -p uaa-control`
- [x] `cargo test --offline -p uaa-control --lib` (133 passed)
- [x] `cargo clippy --offline -p uaa-control --all-targets -- -D warnings` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8fqXPVTDHZS6DMZEFimEJ