### PR TITLE
chore(control): move operator plane from :8443 to :15001

### DIFF
--- a/crates/uaa-control/src/auth.rs
+++ b/crates/uaa-control/src/auth.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/auth.rs
-// version: 1.1.1
+// version: 1.1.2
 // guid: af3dc9c0-def6-46ff-9892-90e54716fe21
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 //! RBAC + operator authentication: GitHub OAuth web flow + org/team role mapping
 //! (spec Decision 8, component C3 "Operator plane").
@@ -32,7 +32,7 @@
 //! default here would silently grant mutation rights while GitHub is down, which is a
 //! worse failure mode than a temporary lockout. No code in this file, or anywhere in
 //! `uaa-control`, implements an alternate way to mint a session. If GitHub itself is
-//! unreachable long enough that operators are fully locked out of the `:8443` plane,
+//! unreachable long enough that operators are fully locked out of the `:15001` plane,
 //! the sanctioned recovery procedure is a human-operated, out-of-band, LOGGED
 //! database mutation:
 //!
@@ -435,7 +435,7 @@ fn percent_encode(input: &str) -> String {
 
 /// Shared operator-auth state: config, the [`GithubApi`] backend, the HMAC key, the
 /// in-flight OAuth `state` map, and the 5-minute role cache. Mount as an
-/// `axum::Extension<Arc<AuthState>>` (or router state) on the `:8443` operator
+/// `axum::Extension<Arc<AuthState>>` (or router state) on the `:15001` operator
 /// router; see [`require_role`] for the middleware contract.
 pub struct AuthState {
     config: AuthConfig,

--- a/crates/uaa-control/src/lib.rs
+++ b/crates/uaa-control/src/lib.rs
@@ -1,13 +1,13 @@
 // file: crates/uaa-control/src/lib.rs
-// version: 1.0.0
+// version: 1.0.1
 // guid: 377e6bf2-0687-480d-a7f4-7bd21c525206
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 //! uaa-control — the constellation's central daemon (spec component C3).
 //!
 //! Owns the registry system-of-record (CockroachDB, Decision 4/5), the four listeners
 //! (`:25000` legacy machine plane via systemd socket activation, plus `:7443` gRPC
-//! mTLS, `:7444` enrollment JSON, `:8443` operator), the embedded schema migrations,
+//! mTLS, `:7444` enrollment JSON, `:15001` operator), the embedded schema migrations,
 //! and the snapshot+WAL degraded-mode layer.
 //!
 //! This crate is scaffolded by CT-01. Most feature surface lands via follower tasks

--- a/crates/uaa-control/src/listeners.rs
+++ b/crates/uaa-control/src/listeners.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/listeners.rs
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4275dc4f-c0cb-479b-9f5c-5a444ed312f7
-// last-edited: 2026-07-12
+// last-edited: 2026-07-13
 
 //! Listener wiring + systemd socket activation (spec Decision 24).
 //!
@@ -10,11 +10,13 @@
 //!     socket activation so a self-update restart never drops the listening socket;
 //!   * `:7443` — gRPC mTLS (services + enrolled agents);
 //!   * `:7444` — enrollment JSON (install-CA-pinned);
-//!   * `:8443` — operator JSON API (first CT-07 slice, see `operator::handlers`'s
+//!   * `:15001` — operator JSON API (first CT-07 slice, see `operator::handlers`'s
 //!     module doc for what's real vs. stubbed) + SPA hosting (`operator::web_ui`).
+//!     Deliberately NOT `:8443` — that's a common alt-HTTPS port other services
+//!     reuse; a high, less-contested port avoids collisions on shared hosts.
 //!
 //! `:7443`/`:7444` remain bind-and-health scaffolds: each serves only `GET /healthz`;
-//! routes and TLS termination arrive with follower tasks (PK-03). `:8443` now serves
+//! routes and TLS termination arrive with follower tasks (PK-03). `:15001` now serves
 //! its real router. Ports bind plain for now (TLS is a runtime concern; tests bind :0).
 
 use std::os::unix::io::RawFd;
@@ -40,7 +42,7 @@ impl Default for ServeConfig {
             machine_plane_port: 25000,
             grpc_port: 7443,
             enroll_port: 7444,
-            operator_port: 8443,
+            operator_port: 15001,
         }
     }
 }
@@ -83,18 +85,16 @@ pub fn parse_listen_fds(
 pub fn health_router(listener: &'static str) -> Router {
     Router::new().route(
         "/healthz",
-        get(move || async move {
-            Json(json!({ "service": "uaa-control", "listener": listener }))
-        }),
+        get(move || async move { Json(json!({ "service": "uaa-control", "listener": listener })) }),
     )
 }
 
 /// Bind and serve all four planes.
 ///
 /// `:25000` uses the socket-activated fd when present (Decision 24), else a plain bind
-/// on `config.machine_plane_port` (dev fallback). `:7443/:7444/:8443` are health
-/// scaffolds (TLS wired later by PK-03/CT-07). Runtime-only; unit tests exercise
-/// [`parse_listen_fds`] and the routers, never this bind loop.
+/// on `config.machine_plane_port` (dev fallback). `:7443`/`:7444` are health scaffolds
+/// (TLS wired later by PK-03); `:15001` serves the real operator router. Runtime-only;
+/// unit tests exercise [`parse_listen_fds`] and the routers, never this bind loop.
 pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     let machine_listener = match sd_listen_fd() {
         Some(fd) => {
@@ -125,7 +125,8 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     });
     let grpc = tokio::spawn(async move { axum::serve(grpc, health_router("grpc")).await });
     let enroll = tokio::spawn(async move { axum::serve(enroll, health_router("enroll")).await });
-    let operator = tokio::spawn(async move { axum::serve(operator, crate::operator::router()).await });
+    let operator =
+        tokio::spawn(async move { axum::serve(operator, crate::operator::router()).await });
 
     // Any listener exiting is fatal; surface the first error.
     let (m, g, e, o) = tokio::try_join!(machine, grpc, enroll, operator)?;

--- a/crates/uaa-control/src/operator/handlers.rs
+++ b/crates/uaa-control/src/operator/handlers.rs
@@ -1,9 +1,9 @@
 // file: crates/uaa-control/src/operator/handlers.rs
-// version: 1.1.0
+// version: 1.2.0
 // guid: e94ff17e-4e1b-4672-8940-1fe111b56861
-// last-edited: 2026-07-12
+// last-edited: 2026-07-13
 
-//! Operator API request handlers (`:8443`, mounted under `/api/*` ahead of
+//! Operator API request handlers (`:15001`, mounted under `/api/*` ahead of
 //! [`super::web_ui`]'s SPA fallback).
 //!
 //! This is a first vertical slice, not the full CT-07 scope: `GET
@@ -291,6 +291,7 @@ pub fn router() -> Router {
 
 fn build_router(state: AppState) -> Router {
     Router::new()
+        .route("/healthz", get(handle_healthz))
         .route("/api/machines", get(handle_list_machines))
         .route("/api/machines/:mac", get(handle_get_machine))
         .route("/api/machines/:mac/approve", post(handle_approve_machine))
@@ -315,6 +316,17 @@ fn build_router(state: AppState) -> Router {
         .route("/api/audit", get(handle_list_audit))
         .route("/api/audit/verify", get(handle_verify_audit))
         .with_state(state)
+}
+
+/// `GET /healthz` — matched here (ahead of `web_ui`'s SPA catch-all
+/// fallback) so it keeps returning the same JSON shape every other plane's
+/// `listeners::health_router` does, instead of silently falling through to
+/// `index.html` once the SPA fallback swallows every unmatched path.
+async fn handle_healthz(State(_state): State<AppState>) -> Response {
+    json_response(
+        StatusCode::OK,
+        serde_json::json!({ "service": "uaa-control", "listener": "operator" }),
+    )
 }
 
 // ── /api/machines (real) ──────────────────────────────────────────────
@@ -636,6 +648,17 @@ mod tests {
             let body = body_json(resp).await;
             assert_eq!(body.as_array().unwrap().len(), 0, "{label}");
         }
+    }
+
+    #[tokio::test]
+    async fn test_healthz_matched_before_spa_fallback_would_swallow_it() {
+        let dir = tempdir().unwrap();
+        let state = test_state(dir.path().to_path_buf(), Arc::new(MockRegistry::default()));
+        let resp = handle_healthz(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["service"], "uaa-control");
+        assert_eq!(body["listener"], "operator");
     }
 
     #[tokio::test]

--- a/crates/uaa-control/src/operator/mod.rs
+++ b/crates/uaa-control/src/operator/mod.rs
@@ -1,9 +1,9 @@
 // file: crates/uaa-control/src/operator/mod.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: c78abe95-9fa9-4dcf-9e4c-14f07d8fb509
-// last-edited: 2026-07-12
+// last-edited: 2026-07-13
 
-//! Operator plane (`:8443`) — JSON API + SPA hosting.
+//! Operator plane (`:15001`) — JSON API + SPA hosting.
 //!
 //! First vertical slice of CT-07 (full OpenAPI/utoipa + auth land later, per
 //! `handlers.rs`'s module doc): [`handlers::router`]'s `/api/*` routes are
@@ -17,7 +17,7 @@ pub mod web_ui;
 
 use axum::Router;
 
-/// The `:8443` router: real/stubbed JSON API, then the SPA for everything else.
+/// The `:15001` router: real/stubbed JSON API, then the SPA for everything else.
 pub fn router() -> Router {
     handlers::router().merge(web_ui::router())
 }

--- a/crates/uaa-control/systemd/uaa-control.service
+++ b/crates/uaa-control/systemd/uaa-control.service
@@ -1,10 +1,10 @@
 # file: crates/uaa-control/systemd/uaa-control.service
-# version: 1.0.0
+# version: 1.0.1
 # guid: 5c164116-d4a3-4715-b230-aa9e1a1e88e3
-# last-edited: 2026-07-10
+# last-edited: 2026-07-13
 #
 # Service unit for the uaa-control daemon (spec C3). Paired with uaa-control.socket so
-# the :25000 machine plane is socket-activated (Decision 24). The :7443/:7444/:8443
+# the :25000 machine plane is socket-activated (Decision 24). The :7443/:7444/:15001
 # planes are bound by the process itself.
 #
 # DEPLOY IS BUCKET-3 (human) WORK: docs/reference artifact only. An operator installs

--- a/scripts/server-deploy.sh
+++ b/scripts/server-deploy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # file: scripts/server-deploy.sh
-# version: 1.1.0
+# version: 1.2.0
 # guid: 9e2f4a71-0b6d-4c8e-9a3f-1d5c7e8b2f60
-# last-edited: 2026-07-11
+# last-edited: 2026-07-13
 #
 # Repeatable build+deploy for the uaa constellation control daemon on the server
 # (172.16.2.30). Lives in the repo so `git pull` always ships the latest version of
@@ -151,7 +151,7 @@ status() {
     systemctl status uaa-control.socket || true
     echo
     echo "--- health checks ---"
-    for port in 25000 7443 7444 8443; do
+    for port in 25000 7443 7444 15001; do
         curl -s -m 2 "http://127.0.0.1:${port}/healthz" && echo || echo "port ${port}: no response"
     done
 }


### PR DESCRIPTION
## Summary
- `:8443` is a common alt-HTTPS port other services reuse; moves the operator plane (SPA + API from #85) to `:15001`, a high, less-contested port.
- Updates `ServeConfig::default()`, doc comments across `listeners.rs`/`lib.rs`/`auth.rs`/`operator/{mod,handlers}.rs`, the systemd unit comment, and `server-deploy.sh`'s `--status` health-check port list.
- **Bug fix found while doing this:** `operator::web_ui`'s SPA catch-all fallback was silently swallowing `GET /healthz` (returning `index.html` instead of the JSON health payload every other plane returns). Added an explicit `/healthz` route in `operator::handlers`, matched ahead of the SPA fallback.

## Test plan
- [x] `cargo test -p uaa-control --lib` (167 passed, 1 new)
- [x] `cargo clippy -p uaa-control --all-targets -- -D warnings` (clean)
- [x] Manual: ran the binary locally — `/healthz` on `:15001` returns `{"service":"uaa-control","listener":"operator"}`, SPA still serves, `:8443` refuses connections (nothing bound there anymore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8fqXPVTDHZS6DMZEFimEJ