### PR TITLE
fix(ci): resolve clippy lint failures from newer stable toolchain

### DIFF
--- a/crates/uaa-control/src/enroll.rs
+++ b/crates/uaa-control/src/enroll.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/enroll.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: 1a81d662-89c9-4e64-8ce9-9aa51fd3a412
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 //! Enrollment plane (`uaa.enroll.v1` gRPC + `:7444` JSON mirror) — CSR submit +
 //! GetCredential poll, idempotent by SPKI fingerprint (spec C6, NORMATIVE).
@@ -880,10 +880,10 @@ mod tests {
                                 saw_real_host = true;
                             }
                         }
-                        x509_parser::extensions::GeneralName::URI(uri) => {
-                            if *uri == "uaa-mac:ff:ff:ff:ff:ff:ff" {
-                                saw_spoofed_mac = true;
-                            }
+                        x509_parser::extensions::GeneralName::URI(uri)
+                            if *uri == "uaa-mac:ff:ff:ff:ff:ff:ff" =>
+                        {
+                            saw_spoofed_mac = true;
                         }
                         _ => {}
                     }

--- a/crates/uaa-core/src/image/manager.rs
+++ b/crates/uaa-core/src/image/manager.rs
@@ -1,5 +1,5 @@
 // file: crates/uaa-core/src/image/manager.rs
-// version: 1.0.2
+// version: 1.0.3
 // guid: n4o5p6q7-r8s9-0123-4567-890123nopqrs
 
 //! Image lifecycle management
@@ -62,7 +62,7 @@ impl ImageManager {
         }
 
         // Sort by creation date (newest first)
-        images.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        images.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         Ok(images)
     }

--- a/crates/uaa-core/src/network/ssh_installer/config.rs
+++ b/crates/uaa-core/src/network/ssh_installer/config.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-core/src/network/ssh_installer/config.rs
-// version: 2.5.3
+// version: 2.5.4
 // guid: sshcfg01-2345-6789-abcd-ef0123456789
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 //! Configuration structures for SSH/local installation
 
@@ -11,19 +11,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// Dracut is used on the actual servers (Lenovo M715q) and requires different
 /// regeneration commands + GRUB kernel parameters for Tang network unlock.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum InitramfsType {
     /// dracut — used on the Lenovo servers. Enables rd.neednet + Tang unlock at boot.
+    #[default]
     Dracut,
     /// initramfs-tools — Ubuntu default (cloud images, live ISOs).
     InitramfsTools,
-}
-
-impl Default for InitramfsType {
-    fn default() -> Self {
-        Self::Dracut
-    }
 }
 
 impl InitramfsType {


### PR DESCRIPTION
## Summary
CI's clippy (rust stable, currently 1.96/1.97) is flagging pre-existing lint debt that the local dev toolchain (1.89, which most recent PRs including mine were verified against) doesn't catch: `unnecessary_sort_by`, `derivable_impls`, and `collapsible_match` got added/promoted since. None of the affected files were touched by the recent operator-plane/dashboard work (PR #83-86) — this is pure hygiene to unblock CI on `main`, prompted by CI failing after #86 merged.

- `crates/uaa-core/src/image/manager.rs`: `sort_by(...)` → `sort_by_key(Reverse(...))`
- `crates/uaa-core/src/network/ssh_installer/config.rs`: manual `impl Default` → `#[derive(Default)]` + `#[default]` on `Dracut`
- `crates/uaa-control/src/enroll.rs` (test-only): collapsed a single-arm match `if` into a match guard

## Test plan
- [x] Updated local toolchain to `rustc 1.97.0` (matching CI's current stable) to verify without waiting on CI round-trips
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean on BOTH 1.89 and 1.97
- [x] `cargo test --workspace --lib` — 594 tests passed on both toolchains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8fqXPVTDHZS6DMZEFimEJ