### PR TITLE
chore(toolchain): pin local dev Rust toolchain to 1.97.0

### DIFF
--- a/crates/uaa-control/src/enroll.rs
+++ b/crates/uaa-control/src/enroll.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-control/src/enroll.rs
-// version: 1.1.0
+// version: 1.1.1
 // guid: 1a81d662-89c9-4e64-8ce9-9aa51fd3a412
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 //! Enrollment plane (`uaa.enroll.v1` gRPC + `:7444` JSON mirror) — CSR submit +
 //! GetCredential poll, idempotent by SPKI fingerprint (spec C6, NORMATIVE).
@@ -880,10 +880,10 @@ mod tests {
                                 saw_real_host = true;
                             }
                         }
-                        x509_parser::extensions::GeneralName::URI(uri) => {
-                            if *uri == "uaa-mac:ff:ff:ff:ff:ff:ff" {
-                                saw_spoofed_mac = true;
-                            }
+                        x509_parser::extensions::GeneralName::URI(uri)
+                            if *uri == "uaa-mac:ff:ff:ff:ff:ff:ff" =>
+                        {
+                            saw_spoofed_mac = true;
                         }
                         _ => {}
                     }

--- a/crates/uaa-core/src/image/manager.rs
+++ b/crates/uaa-core/src/image/manager.rs
@@ -1,5 +1,5 @@
 // file: crates/uaa-core/src/image/manager.rs
-// version: 1.0.2
+// version: 1.0.3
 // guid: n4o5p6q7-r8s9-0123-4567-890123nopqrs
 
 //! Image lifecycle management
@@ -62,7 +62,7 @@ impl ImageManager {
         }
 
         // Sort by creation date (newest first)
-        images.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        images.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         Ok(images)
     }

--- a/crates/uaa-core/src/network/ssh_installer/config.rs
+++ b/crates/uaa-core/src/network/ssh_installer/config.rs
@@ -1,7 +1,7 @@
 // file: crates/uaa-core/src/network/ssh_installer/config.rs
-// version: 2.5.3
+// version: 2.5.4
 // guid: sshcfg01-2345-6789-abcd-ef0123456789
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 //! Configuration structures for SSH/local installation
 
@@ -11,19 +11,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// Dracut is used on the actual servers (Lenovo M715q) and requires different
 /// regeneration commands + GRUB kernel parameters for Tang network unlock.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum InitramfsType {
     /// dracut — used on the Lenovo servers. Enables rd.neednet + Tang unlock at boot.
+    #[default]
     Dracut,
     /// initramfs-tools — Ubuntu default (cloud images, live ISOs).
     InitramfsTools,
-}
-
-impl Default for InitramfsType {
-    fn default() -> Self {
-        Self::Dracut
-    }
 }
 
 impl InitramfsType {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,21 @@
+# file: rust-toolchain.toml
+# version: 1.0.0
+# guid: 8d3f4a5b-6c7d-4e8f-9a0b-1c2d3e4f5a6b
+# last-edited: 2026-07-13
+#
+# Pins the local dev toolchain so `cargo`/`rustc`/`clippy`/`rustfmt` invoked
+# anywhere in this repo resolve to this exact version, regardless of
+# `rustup default`. Without this, a machine's `stable` can silently drift
+# for months behind CI's — the 2026-07-13 CI break (PR #87) was exactly
+# that: CI's floating `stable` (1.96/1.97) enforced clippy lints a
+# months-stale local `stable` (1.89) never surfaced.
+#
+# CI intentionally tests against the FLOATING `stable`/`stable-1` channels
+# (`.github/workflows/reusable-ci.yml`, matrix-driven — this file has no
+# effect there, by design) to catch exactly this kind of drift early. This
+# pin is for local/dev reproducibility only. Bump it deliberately when
+# adopting a newer toolchain — `rustup update stable` locally, then update
+# the `channel` value below to match — rather than letting it drift.
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- Adds `rust-toolchain.toml` pinning the repo's dev toolchain to `1.97.0` (currently latest stable). Without this, `cargo`/`rustc`/`clippy`/`rustfmt` resolve to whatever `rustup default` is on a given machine — which is exactly how local dev sat at 1.89 (8 months stale) while CI's floating `stable` moved to 1.96/1.97 and started enforcing newer clippy lints (PR #87).
- CI is unaffected by design: `reusable-ci.yml`'s matrix explicitly tests the **floating** `stable`/`stable-1` channels — that's the intended drift-detection mechanism, and this pin complements it rather than replacing it. This file only fixes local/dev reproducibility.
- Going forward, bumping the toolchain is a deliberate one-line edit here (plus `rustup update stable` locally) instead of silent drift.

Stacked on **#87** (branched from `fix/ci-clippy-lints` so this PR's own CI is green) — merge #87 first, or merge this after; either order is fine since neither touches the same files.

## Test plan
- [x] `rustc --version` / `cargo --version` inside the repo resolve to `1.97.0` automatically via the pin
- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` (594 tests) all clean under the pinned toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8fqXPVTDHZS6DMZEFimEJ